### PR TITLE
fix: apic-406 recalculate baseUri when updating server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ coverage
 # AMF models
 /demo/*.json
 !demo/apis.json
+
+.idea

--- a/src/ApiMethodDocumentation.js
+++ b/src/ApiMethodDocumentation.js
@@ -397,6 +397,8 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
       return;
     }
     this._server = value;
+    this.baseUri = this._getBaseUri(undefined, value);
+
     this.requestUpdate('server', old);
     this._processServerInfo();
   }
@@ -409,10 +411,8 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
     if (!methodName || !httpMethod) {
       return true;
     }
-    if (methodName.toLowerCase() === httpMethod.toLowerCase()) {
-      return true;
-    }
-    return false;
+
+    return methodName.toLowerCase() === httpMethod.toLowerCase();
   }
 
   constructor() {

--- a/test/api-method-documentation.test.js
+++ b/test/api-method-documentation.test.js
@@ -312,6 +312,42 @@ describe('<api-method-documentation>', function() {
     });
   });
 
+  describe('set server', () => {
+    let element;
+    let callGetBaseUri = false;
+    let _getBaseUriMock;
+
+    beforeEach(async () => {
+      element = await basicFixture();
+      _getBaseUriMock = () => {
+        callGetBaseUri = true;
+      };
+    });
+
+    it('sets new value for server and recalculates baseUri', () => {
+      element._getBaseUri = _getBaseUriMock;
+      assert.isUndefined(element.server);
+
+      element.server = 'test';
+      assert.equal(element.server, 'test');
+      assert.isTrue(callGetBaseUri);
+    });
+
+    it('does not set same value for server nor recalculates baseUri', () => {
+      element._getBaseUri = _getBaseUriMock;
+      assert.isUndefined(element.server);
+
+      element.server = 'test';
+      assert.equal(element.server, 'test');
+      assert.isTrue(callGetBaseUri);
+
+      callGetBaseUri = false;
+      element.server = 'test';
+      assert.equal(element.server, 'test');
+      assert.isFalse(callGetBaseUri);
+    });
+  });
+
   [
     ['Compact model', true],
     ['Full model', false]
@@ -520,13 +556,13 @@ describe('<api-method-documentation>', function() {
         it('sets URL from base uri', async () => {
           const element = await baseUriFixture(amf, endpoint, method);
           await aTimeout();
-          assert.equal(element.endpointUri, 'https://domain.com/people/{personId}');
+          assert.equal(element.endpointUri, 'http://{instance}.domain.com/v1/people/{personId}');
         });
 
         it('sets URL from base uri', async () => {
           const element = await baseUriFixture(amf, endpoint, method);
           await aTimeout();
-          assert.equal(element.endpointUri, 'https://domain.com/people/{personId}');
+          assert.equal(element.endpointUri, 'http://{instance}.domain.com/v1/people/{personId}');
         });
       });
 


### PR DESCRIPTION
Bug: After changing servers, baseUri is not updated with new value
Fix: recalculate baseUri based on new server value and update it if necessary.