### PR TITLE
Fix/apic 459

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ coverage
 # AMF models
 /demo/*.json
 !demo/apis.json
+
+.idea

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = (config) => {
 
       client: {
         mocha: {
-          timeout: 10000
+          timeout: 15000
         }
       },
 

--- a/src/ApiMethodDocumentation.js
+++ b/src/ApiMethodDocumentation.js
@@ -409,10 +409,7 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
     if (!methodName || !httpMethod) {
       return true;
     }
-    if (methodName.toLowerCase() === httpMethod.toLowerCase()) {
-      return true;
-    }
-    return false;
+    return methodName.toLowerCase() === httpMethod.toLowerCase();
   }
 
   constructor() {
@@ -519,7 +516,7 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
    *
    * @param {Object} scheme Model for Expects shape of AMF model.
    * @return {Array<Object>|Object} Either list of properties or a type definition
-   * for a queryString property of RAML's
+   * for a queryString and queryParameters property of RAML's
    */
   _computeQueryParameters(scheme) {
     if (!scheme) {
@@ -533,7 +530,7 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
     const qKey = this._getAmfKey(this.ns.aml.vocabularies.apiContract.queryString);
     result = this._ensureArray(scheme[qKey]);
     if (result) {
-      result = this._resolve(result[0]);
+      result = [this._resolve(result[0])];
     }
     return result;
   }
@@ -657,7 +654,7 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
   /**
    * Computes example headers string for code snippets.
    * @param {Array} headers Headers model from AMF
-   * @return {String|undefind} Computed example value for headers
+   * @return {String|undefined} Computed example value for headers
    */
   _computeSnippetsHeaders(headers) {
     let result;
@@ -674,7 +671,7 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
   /**
    * Computes example payload string for code snippets.
    * @param {Array} payload Payload model from AMF
-   * @return {String|undefind} Computed example value for payload
+   * @return {String|undefined} Computed example value for payload
    */
   _computeSnippetsPayload(payload) {
     if (payload && payload instanceof Array) {

--- a/test/SE-12752.test.js
+++ b/test/SE-12752.test.js
@@ -29,8 +29,8 @@ describe('SE-12752 - query string', function() {
         element = await modelFixture(amf, endpopint, method);
         await aTimeout();
         const qp = element.queryParameters;
-        assert.typeOf(qp, 'object', 'queryParameters is computed');
-        const isNodeShape = element._hasType(qp, element.ns.w3.shacl.NodeShape);
+        assert.isArray(qp, 'queryParameters is computed');
+        const isNodeShape = element._hasType(qp[0], element.ns.w3.shacl.NodeShape);
         assert.isTrue(isNodeShape, 'queryParameters is a NodeShape');
         const node = element.shadowRoot.querySelector('api-parameters-document');
         assert.ok(node, 'document is rendered');
@@ -42,8 +42,8 @@ describe('SE-12752 - query string', function() {
         element = await modelFixture(amf, endpopint, method);
         await aTimeout();
         const qp = element.queryParameters;
-        assert.typeOf(qp, 'object', 'queryParameters is computed');
-        const isNodeShape = element._hasType(qp, element.ns.aml.vocabularies.shapes.ArrayShape);
+        assert.isArray(qp, 'queryParameters is computed');
+        const isNodeShape = element._hasType(qp[0], element.ns.aml.vocabularies.shapes.ArrayShape);
         assert.isTrue(isNodeShape, 'queryParameters is an ArrayShape');
         const node = element.shadowRoot.querySelector('api-parameters-document');
         assert.ok(node, 'document is rendered');
@@ -55,8 +55,8 @@ describe('SE-12752 - query string', function() {
         element = await modelFixture(amf, endpopint, method);
         await aTimeout();
         const qp = element.queryParameters;
-        assert.typeOf(qp, 'object', 'queryParameters is computed');
-        const isNodeShape = element._hasType(qp, element.ns.aml.vocabularies.shapes.UnionShape);
+        assert.isArray(qp, 'queryParameters is computed');
+        const isNodeShape = element._hasType(qp[0], element.ns.aml.vocabularies.shapes.UnionShape);
         assert.isTrue(isNodeShape, 'queryParameters is an UnionShape');
         const node = element.shadowRoot.querySelector('api-parameters-document');
         assert.ok(node, 'document is rendered');


### PR DESCRIPTION
Bug: Missing documentation for methods with queryString node defined.
Fix: Query parameters need to be an array so that _api-parameters-document_ can render its documentation correctly.