### PR TITLE
Fix/apic 412

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -159,7 +159,7 @@ class ComponentDemo extends ApiDemoPage {
       // ['nexmo-sms-api', 'Nexmo SMS API'],
       // ['SE-12957', 'OAS query parameetrs documentation'],
       // ['SE-12959', 'OAS summary field'],
-      // ['SE-12752', 'Query string (SE-12752)'],
+      ['SE-12752', 'Query string (SE-12752)'],
       ['oas-callbacks', 'OAS 3 callbacks']
     ].map(([file, label]) => html`
       <anypoint-item data-src="${file}-compact.json">${label} - compact model</anypoint-item>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-method-documentation",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-method-documentation",
   "description": "A HTTP method documentation build from AMF model",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "license": "Apache-2.0",
   "main": "api-method-documentation.js",
   "keywords": [

--- a/src/ApiMethodDocumentation.js
+++ b/src/ApiMethodDocumentation.js
@@ -409,7 +409,10 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
     if (!methodName || !httpMethod) {
       return true;
     }
-    return methodName.toLowerCase() === httpMethod.toLowerCase();
+    if (methodName.toLowerCase() === httpMethod.toLowerCase()) {
+      return true;
+    }
+    return false;
   }
 
   constructor() {
@@ -516,7 +519,7 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
    *
    * @param {Object} scheme Model for Expects shape of AMF model.
    * @return {Array<Object>|Object} Either list of properties or a type definition
-   * for a queryString and queryParameters property of RAML's
+   * for a queryString property of RAML's
    */
   _computeQueryParameters(scheme) {
     if (!scheme) {
@@ -530,7 +533,7 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
     const qKey = this._getAmfKey(this.ns.aml.vocabularies.apiContract.queryString);
     result = this._ensureArray(scheme[qKey]);
     if (result) {
-      result = [this._resolve(result[0])];
+      result = this._resolve(result[0]);
     }
     return result;
   }
@@ -654,7 +657,7 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
   /**
    * Computes example headers string for code snippets.
    * @param {Array} headers Headers model from AMF
-   * @return {String|undefined} Computed example value for headers
+   * @return {String|undefind} Computed example value for headers
    */
   _computeSnippetsHeaders(headers) {
     let result;
@@ -671,7 +674,7 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
   /**
    * Computes example payload string for code snippets.
    * @param {Array} payload Payload model from AMF
-   * @return {String|undefined} Computed example value for payload
+   * @return {String|undefind} Computed example value for payload
    */
   _computeSnippetsPayload(payload) {
     if (payload && payload instanceof Array) {

--- a/src/ApiMethodDocumentation.js
+++ b/src/ApiMethodDocumentation.js
@@ -409,10 +409,7 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
     if (!methodName || !httpMethod) {
       return true;
     }
-    if (methodName.toLowerCase() === httpMethod.toLowerCase()) {
-      return true;
-    }
-    return false;
+    return methodName.toLowerCase() === httpMethod.toLowerCase();
   }
 
   constructor() {
@@ -664,7 +661,7 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
   /**
    * Computes example headers string for code snippets.
    * @param {Array} headers Headers model from AMF
-   * @return {String|undefind} Computed example value for headers
+   * @return {String|undefined} Computed example value for headers
    */
   _computeSnippetsHeaders(headers) {
     let result;
@@ -681,7 +678,7 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
   /**
    * Computes example payload string for code snippets.
    * @param {Array} payload Payload model from AMF
-   * @return {String|undefind} Computed example value for payload
+   * @return {String|undefined} Computed example value for payload
    */
   _computeSnippetsPayload(payload) {
     if (payload && payload instanceof Array) {

--- a/src/ApiMethodDocumentation.js
+++ b/src/ApiMethodDocumentation.js
@@ -473,21 +473,28 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
     this._processServerInfo();
   }
 
+  _hasQueryParameters() {
+    if (!this.queryParameters) {
+      return false;
+    }
+    return this.queryParameters instanceof Object || this.queryParameters.length
+  }
+
   _expectsChanged(expects) {
     if (!this.endpointVariables) {
       this._processEndpointVariables();
     }
     this.headers = this._computeHeaders(expects);
     this.payload = this._computePayload(expects);
-    const queryParameters = this.queryParameters = this._computeQueryParameters(expects);
-    this.hasParameters = this.hasPathParameters || !!(queryParameters && queryParameters.length);
+    this.queryParameters = this._computeQueryParameters(expects);
+    this.hasParameters = this.hasPathParameters || this._hasQueryParameters();
   }
 
   _processEndpointVariables() {
     const endpointVariables = this.endpointVariables = this._computeEndpointVariables(this.endpoint, this.expects);
     const hasPathParameters = this.hasPathParameters =
       this._computeHasPathParameters(this.serverVariables, endpointVariables);
-    this.hasParameters = hasPathParameters || !!(this.queryParameters && this.queryParameters.length);
+    this.hasParameters = hasPathParameters || this._hasQueryParameters();
   }
 
   /**
@@ -498,7 +505,7 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
     const serverVariables = this.serverVariables = this._computeServerVariables(this.server);
     const hasPathParameters = this.hasPathParameters =
       this._computeHasPathParameters(serverVariables, this.endpointVariables);
-    this.hasParameters = hasPathParameters || !(this.queryParameters && this.queryParameters.length);
+    this.hasParameters = hasPathParameters || this._hasQueryParameters();
     this._processEndpointVariables();
   }
 

--- a/test/SE-12752.test.js
+++ b/test/SE-12752.test.js
@@ -24,42 +24,59 @@ describe('SE-12752 - query string', function() {
       });
 
       it('renders parameters table with query parameters as a NodeShape', async () => {
-        const endpopint = AmfLoader.lookupEndpoint(amf, '/test');
+        const endpoint = AmfLoader.lookupEndpoint(amf, '/test');
         const method = AmfLoader.lookupOperation(amf, '/test', 'get');
-        element = await modelFixture(amf, endpopint, method);
+        element = await modelFixture(amf, endpoint, method);
         await aTimeout();
         const qp = element.queryParameters;
-        assert.isArray(qp, 'queryParameters is computed');
-        const isNodeShape = element._hasType(qp[0], element.ns.w3.shacl.NodeShape);
+        assert.typeOf(qp, 'object', 'queryParameters is computed');
+        const isNodeShape = element._hasType(qp, element.ns.w3.shacl.NodeShape);
         assert.isTrue(isNodeShape, 'queryParameters is a NodeShape');
         const node = element.shadowRoot.querySelector('api-parameters-document');
         assert.ok(node, 'document is rendered');
+        assert.isTrue(element.hasParameters);
       });
 
       it('renders parameters table with query parameters as an ArrayShape', async () => {
-        const endpopint = AmfLoader.lookupEndpoint(amf, '/array');
+        const endpoint = AmfLoader.lookupEndpoint(amf, '/array');
         const method = AmfLoader.lookupOperation(amf, '/array', 'get');
-        element = await modelFixture(amf, endpopint, method);
+        element = await modelFixture(amf, endpoint, method);
         await aTimeout();
         const qp = element.queryParameters;
-        assert.isArray(qp, 'queryParameters is computed');
-        const isNodeShape = element._hasType(qp[0], element.ns.aml.vocabularies.shapes.ArrayShape);
+        assert.typeOf(qp, 'object', 'queryParameters is computed');
+        const isNodeShape = element._hasType(qp, element.ns.aml.vocabularies.shapes.ArrayShape);
         assert.isTrue(isNodeShape, 'queryParameters is an ArrayShape');
         const node = element.shadowRoot.querySelector('api-parameters-document');
         assert.ok(node, 'document is rendered');
+        assert.isTrue(element.hasParameters);
       });
 
       it('renders parameters table with query parameters as an UnionShape', async () => {
-        const endpopint = AmfLoader.lookupEndpoint(amf, '/union');
+        const endpoint = AmfLoader.lookupEndpoint(amf, '/union');
         const method = AmfLoader.lookupOperation(amf, '/union', 'get');
-        element = await modelFixture(amf, endpopint, method);
+        element = await modelFixture(amf, endpoint, method);
         await aTimeout();
         const qp = element.queryParameters;
-        assert.isArray(qp, 'queryParameters is computed');
-        const isNodeShape = element._hasType(qp[0], element.ns.aml.vocabularies.shapes.UnionShape);
+        assert.typeOf(qp, 'object', 'queryParameters is computed');
+        const isNodeShape = element._hasType(qp, element.ns.aml.vocabularies.shapes.UnionShape);
         assert.isTrue(isNodeShape, 'queryParameters is an UnionShape');
         const node = element.shadowRoot.querySelector('api-parameters-document');
         assert.ok(node, 'document is rendered');
+        assert.isTrue(element.hasParameters);
+      });
+
+      it('renders parameters table with query parameters as an ScalarShape', async () => {
+        const endpoint = AmfLoader.lookupEndpoint(amf, '/scalar');
+        const method = AmfLoader.lookupOperation(amf, '/scalar', 'get');
+        element = await modelFixture(amf, endpoint, method);
+        await aTimeout();
+        const qp = element.queryParameters;
+        assert.typeOf(qp, 'object', 'queryParameters is computed');
+        const isScalarShape = element._hasType(qp, element.ns.aml.vocabularies.shapes.ScalarShape);
+        assert.isTrue(isScalarShape, 'queryParameters is an ScalarShape');
+        const node = element.shadowRoot.querySelector('api-parameters-document');
+        assert.ok(node, 'document is rendered');
+        assert.isTrue(element.hasParameters);
       });
     });
   });

--- a/test/SE-12957.test.js
+++ b/test/SE-12957.test.js
@@ -35,6 +35,7 @@ describe('SE-12957', function() {
         const node = element.shadowRoot.querySelector('api-parameters-document');
         assert.typeOf(node.queryParameters, 'array');
         assert.lengthOf(node.queryParameters, 1);
+        assert.isTrue(element.hasParameters);
       });
 
       it('parameters documentation computed endpointParameters', () => {

--- a/test/amf-loader.js
+++ b/test/amf-loader.js
@@ -43,7 +43,7 @@ AmfLoader.lookupEndpoint = function(model, endpoint) {
 };
 
 AmfLoader.lookupOperation = function(model, endpoint, operation) {
-  const endPoint = AmfLoader.lookupEndpoint(model, endpoint, operation);
+  const endPoint = AmfLoader.lookupEndpoint(model, endpoint);
   const opKey = helper._getAmfKey(helper.ns.aml.vocabularies.apiContract.supportedOperation);
   const ops = helper._ensureArray(endPoint[opKey]);
   return ops.find((item) => helper._getValue(item, helper.ns.aml.vocabularies.apiContract.method) === operation);
@@ -56,7 +56,7 @@ AmfLoader.lookupPayload = function(model, endpoint, operation) {
 };
 
 AmfLoader.lookupEndpointOperation = function(model, endpoint, operation) {
-  const endPoint = AmfLoader.lookupEndpoint(model, endpoint, operation);
+  const endPoint = AmfLoader.lookupEndpoint(model, endpoint);
   const opKey = helper._getAmfKey(helper.ns.aml.vocabularies.apiContract.supportedOperation);
   const ops = helper._ensureArray(endPoint[opKey]);
   const op = ops.find((item) => helper._getValue(item, helper.ns.aml.vocabularies.apiContract.method) === operation);


### PR DESCRIPTION
Bug: Missing query parameters. 

Have to revert previous commit as queryParameters can be of type Object and Array. Now, for hasParameters we check if it's an object or if it's an array and has at least one element. With that, parameters section will be rendered.