### PR TITLE
fix: apic-498 add method parameters when computing uri

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 addons:
   chrome: stable
 script:
-- npm prepare
+- npm run generate-model
 - npm test
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run test:sl; fi
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: required
 addons:
   chrome: stable
 script:
+- npm prepare
 - npm test
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run test:sl; fi
 env:

--- a/demo/demo-api/demo-api.raml
+++ b/demo/demo-api/demo-api.raml
@@ -440,3 +440,10 @@ securitySchemes:
       | Local file    |          |      |      |          |           |             |          |   √  |
       | Azure Storage |          |      |      |          |           |             |          |   √  |
       | Amazon S3     |          |      |      |          |           |             |          |   √  |
+/mail:
+  get:
+    queryParameters:
+      box:
+        type: string
+        example: "foo"
+        required: true

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = (config) => {
 
       client: {
         mocha: {
-          timeout: 15000
+          timeout: 20000
         }
       },
 

--- a/karma.sl.config.js
+++ b/karma.sl.config.js
@@ -10,7 +10,7 @@ module.exports = (config) => {
     },
     client: {
       mocha: {
-        timeout: 15000
+        timeout: 20000
       }
     },
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-method-documentation",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-method-documentation",
   "description": "A HTTP method documentation build from AMF model",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "license": "Apache-2.0",
   "main": "api-method-documentation.js",
   "keywords": [

--- a/src/ApiMethodDocumentation.js
+++ b/src/ApiMethodDocumentation.js
@@ -524,15 +524,15 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
 
     const expects = this._computeExpects(method);
     const params = this._computeQueryParameters(expects);
-    if (params) {
+    if (params && Array.isArray(params)) {
       params.forEach(param => {
         const paramExample = this._computeMethodParameterUri(param);
         if (paramExample) {
           if (paramExample.example) {
-            queryParams = `${queryParams ? '&' : '?'}${paramExample.name}=${paramExample.example}`
+            queryParams += `${queryParams ? '&' : '?'}${paramExample.name}=${paramExample.example}`
           } else {
             const examples = paramExample.examples.map(e => `${paramExample.name}=${e}`).join('&')
-            queryParams = `${queryParams ? '&' : '?'}${examples}`
+            queryParams += `${queryParams ? '&' : '?'}${examples}`
           }
         }
       });

--- a/src/ApiMethodDocumentation.js
+++ b/src/ApiMethodDocumentation.js
@@ -511,8 +511,58 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
    * @return {String}
    */
   _computeEndpointUri() {
-    const { server, baseUri, apiVersion: version, endpoint } = this;
-    return this._computeUri(endpoint, { server, baseUri, version });
+    const { server, baseUri, apiVersion: version, endpoint, method } = this;
+    const uri = this._computeUri(endpoint, { server, baseUri, version })
+    return uri + this._computeMethodParametersUri(method);
+  }
+
+  _computeMethodParametersUri(method) {
+    let queryParams = '';
+    if (!method) {
+      return queryParams
+    }
+
+    const expects = this._computeExpects(method);
+    const params = this._computeQueryParameters(expects);
+    if (params) {
+      params.forEach(param => {
+        const paramExample = this._computeMethodParameterUri(param);
+        if (paramExample) {
+          if (paramExample.example) {
+            queryParams = `${queryParams ? '&' : '?'}${paramExample.name}=${paramExample.example}`
+          } else {
+            const examples = paramExample.examples.map(e => `${paramExample.name}=${e}`).join('&')
+            queryParams = `${queryParams ? '&' : '?'}${examples}`
+          }
+        }
+      });
+    }
+    return queryParams
+  }
+
+  _computeMethodParameterUri(param) {
+    if (!this._getValue(param, this.ns.aml.vocabularies.apiContract.required)) {
+      return
+    }
+
+    const paramName = this._getValue(param, this.ns.aml.vocabularies.apiContract.paramName);
+    const paramExample = this._computePropertyValue(param);
+
+    const skey = this._getAmfKey(this.ns.aml.vocabularies.shapes.schema);
+    let schema = param && param[skey];
+    if (schema) {
+      if (schema instanceof Array) {
+        schema = schema[0]
+      }
+      if (this._hasType(schema, this.ns.aml.vocabularies.shapes.ArrayShape)) {
+        const examples = paramExample.split(/\n/).map(e => e.substr(1).trim())
+        return { name: paramName, examples }
+      }
+    }
+
+    if (paramName && paramExample) {
+      return { name: paramName, example: paramExample }
+    }
   }
 
   /**

--- a/test/api-method-documentation.test.js
+++ b/test/api-method-documentation.test.js
@@ -547,7 +547,8 @@ describe('<api-method-documentation>', function() {
             const element = await baseUriFixture(amf, endpoint, method);
             await aTimeout();
             const expectedUri =
-              'https://domain.com/test-parameters/{feature}?numericRepeatable=123&numericRepeatable=456'
+              'https://domain.com/test-parameters/{feature}' +
+              '?testRepeatable=value1&testRepeatable=value2&numericRepeatable=123&numericRepeatable=456'
             assert.equal(element.endpointUri, expectedUri);
           });
         })

--- a/test/api-method-documentation.test.js
+++ b/test/api-method-documentation.test.js
@@ -513,21 +513,44 @@ describe('<api-method-documentation>', function() {
 
         let endpoint;
         let method;
-        beforeEach(() => {
-          [endpoint, method] = AmfLoader.lookupEndpointOperation(amf, '/people/{personId}', 'put');
-        });
 
-        it('sets URL from base uri', async () => {
-          const element = await baseUriFixture(amf, endpoint, method);
-          await aTimeout();
-          assert.equal(element.endpointUri, 'https://domain.com/people/{personId}');
-        });
+        describe('method with no queryParameters', () => {
+          beforeEach(() => {
+            [endpoint, method] = AmfLoader.lookupEndpointOperation(amf, '/people/{personId}', 'put');
+          });
 
-        it('sets URL from base uri', async () => {
-          const element = await baseUriFixture(amf, endpoint, method);
-          await aTimeout();
-          assert.equal(element.endpointUri, 'https://domain.com/people/{personId}');
-        });
+          it('sets URL from base uri', async () => {
+            const element = await baseUriFixture(amf, endpoint, method);
+            await aTimeout();
+            assert.equal(element.endpointUri, 'https://domain.com/people/{personId}');
+          });
+        })
+
+        describe('method with string queryParameter', () => {
+          beforeEach(() => {
+            [endpoint, method] = AmfLoader.lookupEndpointOperation(amf, '/mail', 'get');
+          });
+
+          it('sets URL from base uri', async () => {
+            const element = await baseUriFixture(amf, endpoint, method);
+            await aTimeout();
+            assert.equal(element.endpointUri, 'https://domain.com/mail?box=foo');
+          });
+        })
+
+        describe('method with array queryParameter', () => {
+          beforeEach(() => {
+            [endpoint, method] = AmfLoader.lookupEndpointOperation(amf, '/test-parameters/{feature}', 'get');
+          });
+
+          it('sets URL from base uri', async () => {
+            const element = await baseUriFixture(amf, endpoint, method);
+            await aTimeout();
+            const expectedUri =
+              'https://domain.com/test-parameters/{feature}?numericRepeatable=123&numericRepeatable=456'
+            assert.equal(element.endpointUri, expectedUri);
+          });
+        })
       });
 
       describe('Code snippets', () => {


### PR DESCRIPTION
Bug: When computing uri for an endpoint, query parameters are missing.  For example when computing uri for GET /mail,
```
/mail:
  get:
    queryParameters:
      box:
        type: string
        example: "foo"
        required: true
```
it will return /mail. Now, we are contemplating both endpoint and method and for GET /mail will return /mail?box=foo
