### PR TITLE
Call requestUpdate on baseUri change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-method-documentation",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-method-documentation",
   "description": "A HTTP method documentation build from AMF model",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "license": "Apache-2.0",
   "main": "api-method-documentation.js",
   "keywords": [

--- a/src/ApiMethodDocumentation.js
+++ b/src/ApiMethodDocumentation.js
@@ -359,6 +359,7 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
       return;
     }
     this._baseUri = value;
+    this.requestUpdate('baseUri', old);
     this._processServerInfo();
   }
 

--- a/test/api-method-documentation.test.js
+++ b/test/api-method-documentation.test.js
@@ -859,6 +859,23 @@ describe('<api-method-documentation>', function() {
           assert.exists(element.shadowRoot.querySelector('api-headers-document'));
         });
       });
+
+      describe('<api-url/>', () => {
+        let element;
+
+        beforeEach(async () => {
+          element = await basicFixture();
+        });
+
+        it('should update baseUri in api-url', async () => {
+          element.baseUri = 'http://example.org';
+          await nextFrame();
+          assert.equal(element.shadowRoot.querySelector('api-url').url, 'http://example.org');
+          element.baseUri = 'https://domain.com';
+          await nextFrame();
+          assert.equal(element.shadowRoot.querySelector('api-url').url, 'https://domain.com');
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
`baseUri` change was not being propagated to `api-url` component, so added `requestChange` call in `baseUri` setter