### PR TITLE
Fix issues with URL query params

### DIFF
--- a/demo/APIC-553/APIC-553.raml
+++ b/demo/APIC-553/APIC-553.raml
@@ -1,0 +1,57 @@
+#%RAML 1.0
+baseUri: http://domain.org 
+
+title: Array does not work API
+version: 1.0
+mediaType:  application/json
+
+types:
+  ORX_ARRAY:
+    type: array
+    items: string
+    minItems: 1
+  ORX_STR_WITH_EXAMPLE:
+    type: string
+    example: foo
+
+
+
+/cmt:
+  get:
+    queryParameters:
+      orx:
+        description: List ORX type.
+        type: ORX_ARRAY
+        required: true
+      details:
+        displayName: details
+        type: string
+        required: false
+      modemCount:
+        displayName: modemCount
+        type: string
+        required: false
+    responses:
+      200:
+        body:
+          application/json:
+/cmt-with-qp-example:
+  get:
+    queryParameters:
+      orx:
+        description: ORX type.
+        type: string
+        required: true
+        example: foo
+      details:
+        displayName: details
+        type: string
+        required: false
+      modemCount:
+        displayName: modemCount
+        type: string
+        required: false
+    responses:
+      200:
+        body:
+          application/json:

--- a/demo/apis.json
+++ b/demo/apis.json
@@ -10,5 +10,6 @@
   "SE-12752/SE-12752.raml": "RAML 1.0",
   "oas-callbacks/oas-callbacks.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
   "multi-server/multi-server.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
-  "async-api/async-api.yaml": "ASYNC 2.0"
+  "async-api/async-api.yaml": "ASYNC 2.0",
+  "APIC-553/APIC-553.raml": "RAML 1.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-method-documentation",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-method-documentation",
   "description": "A HTTP method documentation build from AMF model",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "license": "Apache-2.0",
   "main": "api-method-documentation.js",
   "keywords": [

--- a/src/ApiUrl.js
+++ b/src/ApiUrl.js
@@ -204,7 +204,7 @@ export class ApiUrl extends AmfHelperMixin(LitElement) {
     if (_protocol) {
       options.protocols = [_protocol];
     }
-    this._url = this._computeUri(_endpoint, options) + this._computeMethodParametersUri(this.operation);
+    this._url = this._computeUri(_endpoint, options);
     this._dispatchChangeEvent();
   }
 
@@ -235,54 +235,5 @@ export class ApiUrl extends AmfHelperMixin(LitElement) {
         }
       })
     );
-  }
-
-  _computeMethodParametersUri(method) {
-    let queryParams = '';
-    if (!method) {
-      return queryParams;
-    }
-
-    const expects = this._computeExpects(method);
-    const params = this._computeQueryParameters(expects);
-    if (params && Array.isArray(params)) {
-      params.forEach((param) => {
-        const paramExample = this._computeMethodParameterUri(param);
-        if (paramExample) {
-          if (paramExample.example) {
-            queryParams += `${queryParams ? '&' : '?'}${paramExample.name}=${paramExample.example}`;
-          } else {
-            const examples = paramExample.examples.map((e) => `${paramExample.name}=${e}`).join('&');
-            queryParams += `${queryParams ? '&' : '?'}${examples}`;
-          }
-        }
-      });
-    }
-    return queryParams;
-  }
-
-  _computeMethodParameterUri(param) {
-    if (!this._getValue(param, this.ns.aml.vocabularies.apiContract.required)) {
-      return;
-    }
-
-    const paramName = this._getValue(param, this.ns.aml.vocabularies.apiContract.paramName);
-    const paramExample = this._computePropertyValue(param);
-
-    const skey = this._getAmfKey(this.ns.aml.vocabularies.shapes.schema);
-    let schema = param && param[skey];
-    if (schema) {
-      if (schema instanceof Array) {
-        schema = schema[0];
-      }
-      if (paramExample && this._hasType(schema, this.ns.aml.vocabularies.shapes.ArrayShape)) {
-        const examples = paramExample.split(/\n/).map((e) => e.substr(1).trim());
-        return { name: paramName, examples };
-      }
-    }
-
-    if (paramName && paramExample) {
-      return { name: paramName, example: paramExample };
-    }
   }
 }

--- a/src/ApiUrl.js
+++ b/src/ApiUrl.js
@@ -275,7 +275,7 @@ export class ApiUrl extends AmfHelperMixin(LitElement) {
       if (schema instanceof Array) {
         schema = schema[0];
       }
-      if (this._hasType(schema, this.ns.aml.vocabularies.shapes.ArrayShape)) {
+      if (paramExample && this._hasType(schema, this.ns.aml.vocabularies.shapes.ArrayShape)) {
         const examples = paramExample.split(/\n/).map((e) => e.substr(1).trim());
         return { name: paramName, examples };
       }

--- a/test/amf-loader.js
+++ b/test/amf-loader.js
@@ -65,3 +65,8 @@ AmfLoader.lookupEndpointOperation = function(model, endpoint, operation) {
 AmfLoader.getEncodes = function(model) {
   return helper._computeEncodes(model)
 }
+
+AmfLoader.getServers = function(model) {
+  helper.amf = model;
+  return helper._getServers({});
+}

--- a/test/api-method-documentation.test.js
+++ b/test/api-method-documentation.test.js
@@ -533,10 +533,10 @@ describe('<api-method-documentation>', function() {
             [endpoint, method] = AmfLoader.lookupEndpointOperation(amf, '/mail', 'get');
           });
 
-          it('sets URL from base uri', async () => {
+          it('sets snippets URL from base uri', async () => {
             const element = await baseUriFixture(amf, endpoint, method);
             await aTimeout();
-            assert.equal(element.endpointUri, 'https://domain.com/mail?box=foo');
+            assert.equal(element.snippetsUri, 'https://domain.com/mail?box=foo');
           });
         })
 
@@ -545,13 +545,13 @@ describe('<api-method-documentation>', function() {
             [endpoint, method] = AmfLoader.lookupEndpointOperation(amf, '/test-parameters/{feature}', 'get');
           });
 
-          it('sets URL from base uri', async () => {
+          it('sets snippets URL from base uri', async () => {
             const element = await baseUriFixture(amf, endpoint, method);
             await aTimeout();
             const expectedUri =
               'https://domain.com/test-parameters/{feature}' +
               '?testRepeatable=value1&testRepeatable=value2&numericRepeatable=123&numericRepeatable=456'
-            assert.equal(element.endpointUri, expectedUri);
+            assert.equal(element.snippetsUri, expectedUri);
           });
         })
       });

--- a/test/api-method-documentation.test.js
+++ b/test/api-method-documentation.test.js
@@ -321,6 +321,7 @@ describe('<api-method-documentation>', function() {
       const driveApi = 'google-drive-api';
       const callbacksApi = 'oas-callbacks';
       const asyncApi = 'async-api';
+      const apic553 = 'APIC-553';
 
       describe('Basic AMF computations', () => {
         let amf;
@@ -876,6 +877,54 @@ describe('<api-method-documentation>', function() {
           assert.equal(element.shadowRoot.querySelector('api-url').url, 'https://domain.com');
         });
       });
+    
+      describe('APIC-553', () => {
+        let amf;
+        let element;
+
+        before(async () => {
+          amf = await AmfLoader.load(apic553, compact);
+        });
+
+        beforeEach(async () => {
+          const [endpoint, method] = AmfLoader.lookupEndpointOperation(amf, '/cmt', 'get');
+          const server = AmfLoader.getServers(amf)[0];
+          element = await codeSnippetsFixture(amf, endpoint, method);
+          element.server = server;
+          await nextFrame();
+        });
+
+        it('should set endpointUri', async () => {
+          assert.equal(element.endpointUri, 'http://domain.org/cmt');
+        });
+
+        it('should set code snippet with endpoint uri and no query params', async () => {
+          element._toggleSnippets();
+          await nextFrame();
+          assert.equal(element.shadowRoot.querySelector('http-code-snippets').url, 'http://domain.org/cmt');
+        });
+
+        describe('with query param example', () => {
+          beforeEach(async () => {
+            const [endpoint, method] = AmfLoader.lookupEndpointOperation(amf, '/cmt-with-qp-example', 'get');
+            const server = AmfLoader.getServers(amf)[0];
+            element = await codeSnippetsFixture(amf, endpoint, method);
+            element.server = server;
+            await nextFrame();
+          });
+
+          it('should set endpointUri without query params', async () => {
+            assert.equal(element.endpointUri, 'http://domain.org/cmt-with-qp-example');
+          });
+
+          it('should set code snippet with endpoint uri and query param', async () => {
+            element._toggleSnippets();
+            await nextFrame();
+            const newLocal = element.shadowRoot.querySelector('http-code-snippets');
+            assert.equal(newLocal.url, 'http://domain.org/cmt-with-qp-example?orx=foo');
+          });
+        });
+      })
     });
   });
 });


### PR DESCRIPTION
- Fixed bug where query params without examples were causing an error
- Snippet URLs include query params, endpoint URL does not