### PR TITLE
Do not render method if component has no method defined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-method-documentation",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-method-documentation",
   "description": "A HTTP method documentation build from AMF model",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "license": "Apache-2.0",
   "main": "api-method-documentation.js",
   "keywords": [

--- a/src/ApiUrl.js
+++ b/src/ApiUrl.js
@@ -151,19 +151,26 @@ export class ApiUrl extends AmfHelperMixin(LitElement) {
   }
 
   render() {
-    const method = this._method;
     const url = this.url;
     return html`
       <style>
         ${this.styles}
       </style>
       <section class="url-area">
-        <div class="method-value"><span class="method-label" data-method="${method}">${method}</span></div>
+        ${this._getMethodTemplate()}
         ${this._getPathTemplate()}
         <div class="url-value">${url}</div>
       </section>
       <clipboard-copy id="urlCopy" .content="${url}"></clipboard-copy>
     `;
+  }
+
+  _getMethodTemplate() {
+    const method = this._method;
+    if (!method) {
+      return html``;
+    }
+    return html`<div class="method-value"><span class="method-label" data-method="${method}">${method}</span></div>`
   }
 
   _getPathTemplate() {

--- a/test/api-url.test.js
+++ b/test/api-url.test.js
@@ -68,6 +68,16 @@ describe('<api-url>', function () {
 		it('should compute method', () => {
 		  assert.equal(element._method, 'GET');
 		});
+
+		it('should render method', () => {
+			assert.exists(element.shadowRoot.querySelector('.method-value'));
+		})
+
+		it('should not render method if method is not present', async () => {
+			element.operation = null;
+			await nextFrame();
+			assert.notExists(element.shadowRoot.querySelector('.method-value'));
+		})
 	  });
 
 	  describe('AsyncAPI', () => {

--- a/test/api-url.test.js
+++ b/test/api-url.test.js
@@ -70,14 +70,14 @@ describe('<api-url>', function () {
 		});
 
 		it('should render method', () => {
-			assert.exists(element.shadowRoot.querySelector('.method-value'));
-		})
+		  assert.exists(element.shadowRoot.querySelector('.method-value'));
+		});
 
 		it('should not render method if method is not present', async () => {
-			element.operation = null;
-			await nextFrame();
-			assert.notExists(element.shadowRoot.querySelector('.method-value'));
-		})
+		  element.operation = null;
+		  await nextFrame();
+		  assert.notExists(element.shadowRoot.querySelector('.method-value'));
+		});
 	  });
 
 	  describe('AsyncAPI', () => {


### PR DESCRIPTION
If `api-url` does not have any `method` property, then it should not render method label or method value