### PR TITLE
Fix message schema rendering for Subscribe operations

### DIFF
--- a/demo/APIC-582/APIC-582.yaml
+++ b/demo/APIC-582/APIC-582.yaml
@@ -1,0 +1,23 @@
+asyncapi: 2.0.0
+info:
+  title: Account service
+  version: 1.0.0
+  description: This service is in charge of processing user signups
+channels: 
+  user/signedup:
+    subscribe:
+      message:
+        $ref: '#/components/messages/UserSignedUp'
+components:
+  messages:
+    UserSignedUp:
+      payload:
+        type: object
+        properties:
+          displayName:
+            type: string
+            description: Name of the user
+          email:
+            type: string
+            format: email
+            description: Email of user

--- a/demo/apis.json
+++ b/demo/apis.json
@@ -12,5 +12,6 @@
   "multi-server/multi-server.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
   "async-api/async-api.yaml": "ASYNC 2.0",
   "APIC-553/APIC-553.raml": "RAML 1.0",
-  "APIC-560/APIC-560.yaml": "ASYNC 2.0"
+  "APIC-560/APIC-560.yaml": "ASYNC 2.0",
+  "APIC-582/APIC-582.yaml": "ASYNC 2.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,12 +45,12 @@
       }
     },
     "@advanced-rest-client/arc-events": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-events/-/arc-events-0.2.13.tgz",
-      "integrity": "sha512-I5Cx+jYqS4BXoJ1+noWMDbUefTctCqmzZkpfxF0brld8icn/lAeaHV9yu4rizdjx+sc3ps+Co57SmIC9MrTvYw==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-events/-/arc-events-0.2.14.tgz",
+      "integrity": "sha512-wP5m2nB1DzhDZX1CI1xR/6jmpPfSmxdjkU+T/g/esxR28ikrWmk05FitAgbkXDRuqr1Roj50r7PnaepqilH+Mw==",
       "dev": true,
       "requires": {
-        "@advanced-rest-client/arc-types": "^0.2.40"
+        "@advanced-rest-client/arc-types": "^0.2.49"
       }
     },
     "@advanced-rest-client/arc-fit-mixin": {
@@ -84,9 +84,9 @@
       }
     },
     "@advanced-rest-client/arc-icons": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-icons/-/arc-icons-3.2.2.tgz",
-      "integrity": "sha512-4KC2Amg7Bzaty0q0H2QsyZlfx0ceFdyN/WGrj1UXF98RdXtmKX8tBK9PrgHSnuaBWw1l/u/ZmjmXle6uXG6xvA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-icons/-/arc-icons-3.3.0.tgz",
+      "integrity": "sha512-eyiSSBByyKKId+TTC4jPCM6hSiQ7rLypJHQzviqrqqdA72zx8QJkZqpKlC7oZZoGOFTttNjCXTPEFQu8/OdA6w==",
       "requires": {
         "@polymer/iron-icon": "^3.0.1",
         "@polymer/iron-iconset-svg": "^3.0.1",
@@ -106,13 +106,13 @@
       }
     },
     "@advanced-rest-client/arc-models": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-models/-/arc-models-4.2.7.tgz",
-      "integrity": "sha512-ioyfCKICipjC25GHb4U1spyQJM+rESfHM2AUh7Lfky9NhH0t1eH/qg/iZMHev8+GqAMtSjVC99c1VLAZU+VOcA==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-models/-/arc-models-4.2.9.tgz",
+      "integrity": "sha512-DoCykRU0hnj+gCgT9cuEF0vrWTjFIrgWVOaRDjGMWNep2O2lbuvjoWlcLeyMuQMPS6hVv4nUO3yHK94xrMTbZg==",
       "dev": true,
       "requires": {
         "@advanced-rest-client/arc-electron-payload-processor": "^1.0.1",
-        "@advanced-rest-client/arc-events": "^0.2.10",
+        "@advanced-rest-client/arc-events": "^0.2.14",
         "@advanced-rest-client/arc-url": "^0.1.3",
         "@advanced-rest-client/pouchdb-quick-search": "^2.0.3",
         "@advanced-rest-client/uuid-generator": "^3.1.1",
@@ -140,31 +140,31 @@
       }
     },
     "@advanced-rest-client/arc-response": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-response/-/arc-response-0.1.6.tgz",
-      "integrity": "sha512-3WEbjTySTZElnfq8DnW8ojsht2yqjOHCNpiMv9s/mUvb8thHXyEIryXj/TipOR8rD7CctkwyzsYv4JNt73feLA==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-response/-/arc-response-0.1.10.tgz",
+      "integrity": "sha512-L5LzpdZcusaVuGU7EkIm9GVg794kynwZFEfVbpRmZDb1d6fkx0TNucGZ6z5RJzwMebnoXyewK7feHUQNaOSPXw==",
       "dev": true,
       "requires": {
-        "@advanced-rest-client/arc-events": "^0.2.13",
-        "@advanced-rest-client/arc-headers": "^0.1.5",
-        "@advanced-rest-client/arc-icons": "^3.2.2",
-        "@advanced-rest-client/arc-types": "^0.2.43",
+        "@advanced-rest-client/arc-events": "^0.2.14",
+        "@advanced-rest-client/arc-headers": "^0.1.7",
+        "@advanced-rest-client/arc-icons": "^3.3.0",
+        "@advanced-rest-client/arc-types": "^0.2.49",
         "@advanced-rest-client/date-time": "^3.0.2",
         "@advanced-rest-client/prism-highlight": "^4.0.2",
-        "@anypoint-web-components/anypoint-button": "^1.0.15",
-        "@anypoint-web-components/anypoint-item": "^1.0.5",
+        "@anypoint-web-components/anypoint-button": "^1.2.0",
+        "@anypoint-web-components/anypoint-item": "^1.1.0",
         "@anypoint-web-components/anypoint-listbox": "^1.1.6",
         "@anypoint-web-components/anypoint-menu-button": "^0.1.4",
         "@polymer/paper-progress": "^3.0.0",
         "lit-element": "^2.4.0",
         "lit-html": "^1.3.0",
-        "prismjs": "^1.22.0"
+        "prismjs": "^1.23.0"
       }
     },
     "@advanced-rest-client/arc-types": {
-      "version": "0.2.47",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-types/-/arc-types-0.2.47.tgz",
-      "integrity": "sha512-SvndHSMFap8nTSmxev3cu8at/WYxox6EIAXj7e4YXYCIRiYv8Ge+BlftD9lhiKjqoiojOv70V74rHsj83XSl3w=="
+      "version": "0.2.49",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/arc-types/-/arc-types-0.2.49.tgz",
+      "integrity": "sha512-bAGqtedKqocYXJgkvkSrrBW6acmcGYYZq96oSVY5lWIvAqkXjgqz8ryXuoeoZ/qxBzwYAxAOmjteUkJTqFJshA=="
     },
     "@advanced-rest-client/arc-url": {
       "version": "0.1.3",
@@ -190,23 +190,23 @@
       }
     },
     "@advanced-rest-client/authorization-method": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/authorization-method/-/authorization-method-0.2.2.tgz",
-      "integrity": "sha512-h5w7OxUho7AO5BzdyyclRWbH/DYFyq1b2gXAQj76uyGx6OyeivGJo12ucge8Cx0JAXLIsLL1zC35kbzKGGBlVQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/authorization-method/-/authorization-method-0.2.4.tgz",
+      "integrity": "sha512-RE+eYfrQaKTb6NmcEjwzgxW0uauywqV1ghk9eXFbrQB1tbuoQBFN/Rs1tH59kGRDnDsvgU6jSdtrESD670F5BA==",
       "dev": true,
       "requires": {
-        "@advanced-rest-client/arc-events": "^0.2.5",
-        "@advanced-rest-client/arc-icons": "^3.1.2",
-        "@advanced-rest-client/arc-types": "^0.2.27",
+        "@advanced-rest-client/arc-events": "^0.2.14",
+        "@advanced-rest-client/arc-icons": "^3.3.0",
+        "@advanced-rest-client/arc-types": "^0.2.49",
         "@advanced-rest-client/clipboard-copy": "^3.0.1",
         "@advanced-rest-client/events-target-mixin": "^3.2.3",
         "@advanced-rest-client/oauth2-scope-selector": "^4.0.0",
-        "@anypoint-web-components/anypoint-button": "^1.1.1",
+        "@anypoint-web-components/anypoint-button": "^1.2.0",
         "@anypoint-web-components/anypoint-checkbox": "^1.1.3",
-        "@anypoint-web-components/anypoint-dialog": "^0.1.6",
+        "@anypoint-web-components/anypoint-dialog": "^0.1.7",
         "@anypoint-web-components/anypoint-dropdown-menu": "^0.1.20",
-        "@anypoint-web-components/anypoint-input": "^0.2.23",
-        "@anypoint-web-components/anypoint-item": "^1.0.8",
+        "@anypoint-web-components/anypoint-input": "^0.2.24",
+        "@anypoint-web-components/anypoint-item": "^1.1.0",
         "@anypoint-web-components/anypoint-listbox": "^1.1.6",
         "@anypoint-web-components/anypoint-switch": "^0.1.4",
         "@open-wc/dedupe-mixin": "^1.3.0",
@@ -403,13 +403,13 @@
       }
     },
     "@advanced-rest-client/oauth-authorization": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/oauth-authorization/-/oauth-authorization-5.0.3.tgz",
-      "integrity": "sha512-2PibisZeuSwvKHgiH2wGgdVxurORu+9jqUIEZgC8wryD2wXUmJohg2po9LqoQtwg6xNgD0K64eLZHDYSX6y02A==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/oauth-authorization/-/oauth-authorization-5.0.5.tgz",
+      "integrity": "sha512-FAoxyiRMNYlV2HEH7G9WhGsz+kBm6Xi1AiZUD6628VL/+hnswDnp+NkCjeDOmtoLUwXHtTDqsHu+JOayEYSEQw==",
       "dev": true,
       "requires": {
-        "@advanced-rest-client/arc-events": "^0.2.13",
-        "@advanced-rest-client/arc-types": "^0.2.45",
+        "@advanced-rest-client/arc-events": "^0.2.14",
+        "@advanced-rest-client/arc-types": "^0.2.49",
         "@advanced-rest-client/events-target-mixin": "^3.2.3",
         "@advanced-rest-client/headers-parser-mixin": "^3.2.0",
         "@polymer/iron-meta": "^3.0.0",
@@ -544,13 +544,13 @@
       }
     },
     "@anypoint-web-components/anypoint-button": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-button/-/anypoint-button-1.1.1.tgz",
-      "integrity": "sha512-S+cfMd5GRepD+133ajGwCNGG+nzTQnH88kcXzbG+Nsl2yC7FQRNNO6N0VQFsfuRl7e+FwWAp3W2iM/HxoAO1kg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-button/-/anypoint-button-1.2.0.tgz",
+      "integrity": "sha512-z3og4oxSlwo37ISbg4S32/NeOqtJcsEfAk4CQ1c4tJM/TsI+lTFLZHwNELeunRg8yoGGnjhrnrxTbin+YKfYBQ==",
       "requires": {
-        "@anypoint-web-components/anypoint-control-mixins": "^1.1.1",
+        "@anypoint-web-components/anypoint-control-mixins": "^1.1.3",
         "@polymer/paper-ripple": "^3.0.2",
-        "lit-element": "^2.3.1"
+        "lit-element": "^2.4.0"
       }
     },
     "@anypoint-web-components/anypoint-checkbox": {
@@ -583,12 +583,12 @@
       }
     },
     "@anypoint-web-components/anypoint-dialog": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-dialog/-/anypoint-dialog-0.1.6.tgz",
-      "integrity": "sha512-BAne4mYs8zp2RlzoB8RWDqRIHvke7ezMQj8qGT6xgHO96j5p8uF2tjbaX5Py50JXeMDsvj8JuZUPJFlzqAxWOA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-dialog/-/anypoint-dialog-0.1.7.tgz",
+      "integrity": "sha512-QCcLDVD14UPfXRfAJfvtv/L/zREog8saUtnVadCqaZihwvNXxQ5pDTR6bAN5H5AptIwjdHsaBMHD/g8M/SMZpA==",
       "dev": true,
       "requires": {
-        "@advanced-rest-client/arc-overlay-mixin": "^1.1.6",
+        "@advanced-rest-client/arc-overlay-mixin": "^1.1.7",
         "@open-wc/dedupe-mixin": "^1.3.0",
         "lit-element": "^2.4.0",
         "lit-html": "^1.3.0"
@@ -629,9 +629,9 @@
       }
     },
     "@anypoint-web-components/anypoint-input": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-input/-/anypoint-input-0.2.23.tgz",
-      "integrity": "sha512-nM1cOXJPuSh1maNsM34YmrQDgGSynF5ZuvG3s9Q3jmv+uaf7RtIj94tO/+TZ8RkHSZJ2FtUl0FsWEtP6bTPfNw==",
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-input/-/anypoint-input-0.2.24.tgz",
+      "integrity": "sha512-IFxwuolKXBtGDmWGqfmdlJwzGlAJr7fE56tNqMrdqCNHEEJvxcWBxIXiWDfnN7SctuqQDkX1Oz+o9wIe3k2tlw==",
       "dev": true,
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.1.2",
@@ -644,11 +644,11 @@
       }
     },
     "@anypoint-web-components/anypoint-item": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-item/-/anypoint-item-1.0.8.tgz",
-      "integrity": "sha512-eqS74CXXIHHyU0Q9QbubfOqURQBLlZETRSJ/qs3AE47Hg6qO1Hr8DNy15qwECGsdm/rZ611K73ZJCuQtC0FRSA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@anypoint-web-components/anypoint-item/-/anypoint-item-1.1.0.tgz",
+      "integrity": "sha512-a4Lz1p5vpdgxeQ4sTAr23kiV9cvKAQ6aVGXRbrEOVYpXKkBJVlkWPvIJ44i14e6APW9F4kY0nczQayAn83QDfg==",
       "requires": {
-        "@anypoint-web-components/anypoint-control-mixins": "^1.1.2",
+        "@anypoint-web-components/anypoint-control-mixins": "^1.1.3",
         "@anypoint-web-components/anypoint-styles": "^1.0.1",
         "lit-element": "^2.4.0",
         "lit-html": "^1.3.0"
@@ -778,21 +778,21 @@
       }
     },
     "@api-components/api-authorization": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@api-components/api-authorization/-/api-authorization-0.5.0.tgz",
-      "integrity": "sha512-v0Q8fz9P/IAv5x6zZKcTVD7q9nh71Wn46GtuX3l6BmvE4Lq7Dg9bc/vYoZzlRZ9hErIyKDlitsJZVsGoGEimtQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@api-components/api-authorization/-/api-authorization-0.5.1.tgz",
+      "integrity": "sha512-zH3P/yxtZw74lw0ZS3ePpm1JTWK75u7JkqQct3or9y78jzfLqugZD6zAWhea4oql+3pZq6nD4saV9nVEouMAAQ==",
       "dev": true,
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.2.2",
         "@advanced-rest-client/arc-marked": "^1.1.0",
         "@advanced-rest-client/arc-types": "^0.2.47",
-        "@advanced-rest-client/authorization-method": "^0.2.2",
+        "@advanced-rest-client/authorization-method": "^0.2.3",
         "@advanced-rest-client/events-target-mixin": "^3.1.1",
         "@anypoint-web-components/anypoint-button": "^1.1.1",
         "@anypoint-web-components/anypoint-dropdown-menu": "^0.1.14",
         "@anypoint-web-components/anypoint-item": "^1.0.5",
         "@anypoint-web-components/anypoint-listbox": "^1.0.4",
-        "@api-components/amf-helper-mixin": "^4.3.2",
+        "@api-components/amf-helper-mixin": "^4.3.4",
         "@api-components/api-forms": "^0.1.2",
         "@open-wc/dedupe-mixin": "^1.3.0",
         "lit-element": "^2.3.1",
@@ -818,9 +818,9 @@
       }
     },
     "@api-components/api-body-editor": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@api-components/api-body-editor/-/api-body-editor-4.0.5.tgz",
-      "integrity": "sha512-UE7QTIxEA36jRlxrzJcsKZ1YU9A7UAYk75UCLDq+twR+hPlJzYW39UW8sotpviWMd/5V1mPfk75VfIYRPBTYrg==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@api-components/api-body-editor/-/api-body-editor-4.0.6.tgz",
+      "integrity": "sha512-n+y3K29cCBgG4nWbmq1Gs1vtUbkI7Q23rMyxZofQ//TErwLK9y6K21KGJGHLUiEWjW5qYtTA+5LmRoB6mdKh+g==",
       "dev": true,
       "requires": {
         "@advanced-rest-client/clipboard-copy": "^3.0.1",
@@ -922,17 +922,17 @@
       }
     },
     "@api-components/api-navigation": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@api-components/api-navigation/-/api-navigation-4.2.4.tgz",
-      "integrity": "sha512-TB/3aQ3s0d3Cr2mYG9cKWWzXEI/rEQb2KAu7lvSNzEBKmlKz8HbhLhyBMio22CZXwQPoQgmZlsnkFZZDT386Hw==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@api-components/api-navigation/-/api-navigation-4.2.6.tgz",
+      "integrity": "sha512-PmplRckJBM+i38ECOHkvlZsjDhLnEseNQQcHy3cuizMroeFChY5BLNn6fjXHDBnDm2GPMqOssfbUhVFZUTJvvA==",
       "dev": true,
       "requires": {
-        "@advanced-rest-client/arc-icons": "^3.1.0",
+        "@advanced-rest-client/arc-icons": "^3.2.2",
         "@anypoint-web-components/anypoint-button": "^1.1.1",
-        "@api-components/amf-helper-mixin": "^4.1.2",
-        "@api-components/http-method-label": "^3.1.1",
+        "@anypoint-web-components/anypoint-collapse": "^0.1.0",
+        "@api-components/amf-helper-mixin": "^4.3.4",
+        "@api-components/http-method-label": "^3.1.3",
         "@api-components/raml-aware": "^3.0.0",
-        "@polymer/iron-collapse": "^3.0.0",
         "lit-element": "^2.3.1",
         "lit-html": "^1.2.1"
       }
@@ -969,9 +969,9 @@
       }
     },
     "@api-components/api-request": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@api-components/api-request/-/api-request-0.1.0.tgz",
-      "integrity": "sha512-kv81bXvri2vnjmxh9ACh5l+jbeAmjko+Rz2ERrTj/nor5oLRACxilUqR6F6yPdNzgox4y2sHdStuGUYXK7HctA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@api-components/api-request/-/api-request-0.1.4.tgz",
+      "integrity": "sha512-26TUZ8QcRJFDhuVKolBfh0Qw031TJBKvUlzAVYAZJXR427tTuX+mvxClABcU/lGq1wAiA2FdBnHgFZnqud6aGw==",
       "dev": true,
       "requires": {
         "@advanced-rest-client/arc-events": "^0.2.13",
@@ -982,18 +982,18 @@
         "@advanced-rest-client/arc-url": "^0.1.3",
         "@advanced-rest-client/events-target-mixin": "^3.2.3",
         "@advanced-rest-client/http-method-selector": "^3.0.5",
-        "@advanced-rest-client/oauth-authorization": "^5.0.3",
+        "@advanced-rest-client/oauth-authorization": "^5.0.4",
         "@advanced-rest-client/uuid-generator": "^3.1.1",
         "@anypoint-web-components/anypoint-button": "^1.1.1",
-        "@api-components/amf-helper-mixin": "^4.2.0",
-        "@api-components/api-authorization": "^0.5.0",
+        "@api-components/amf-helper-mixin": "^4.3.4",
+        "@api-components/api-authorization": "^0.5.1",
         "@api-components/api-body-editor": "^4.0.5",
         "@api-components/api-forms": "^0.1.2",
         "@api-components/api-headers": "^0.1.0",
-        "@api-components/api-server-selector": "^0.6.2",
-        "@api-components/api-url": "^0.1.0",
+        "@api-components/api-server-selector": "^0.6.3",
+        "@api-components/api-url": "^0.1.1",
         "cryptojslib": "^3.1.2",
-        "jsrsasign": "^10.1.4",
+        "jsrsasign": "^10.1.5",
         "lit-element": "^2.4.0",
         "lit-html": "^1.3.0"
       }
@@ -1032,17 +1032,17 @@
       }
     },
     "@api-components/api-schema-document": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@api-components/api-schema-document/-/api-schema-document-4.1.0.tgz",
-      "integrity": "sha512-Aca8ojU9kvkNVmsop9/Cj3Vwf5JK4q51jQy3CsYN9oFlUa1bAjasjwcvzDQvs6ceTX9bt9DbL+FdYdJ5kmDNQQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@api-components/api-schema-document/-/api-schema-document-4.2.0.tgz",
+      "integrity": "sha512-wJQg8wkOlxXzN2Iak83vuOMurz/jI8eyDjagPkGWjceQF1FTtAiDaomlKQ7HJZTPp39wSr1Bbzjrdw6Y+9wbXQ==",
       "requires": {
+        "@advanced-rest-client/arc-types": "^0.2.47",
         "@advanced-rest-client/prism-highlight": "^4.0.2",
-        "@anypoint-web-components/anypoint-tabs": "^0.1.10",
-        "@api-components/amf-helper-mixin": "^4.1.1",
-        "@api-components/api-example-generator": "^4.2.0",
-        "@api-components/raml-aware": "^3.0.0",
+        "@anypoint-web-components/anypoint-tabs": "^0.1.12",
+        "@api-components/amf-helper-mixin": "^4.3.4",
+        "@api-components/api-example-generator": "^4.4.6",
         "@polymer/prism-element": "^3.0.0",
-        "lit-element": "^2.3.1"
+        "lit-element": "^2.4.0"
       }
     },
     "@api-components/api-security-documentation": {
@@ -1062,9 +1062,9 @@
       }
     },
     "@api-components/api-server-selector": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@api-components/api-server-selector/-/api-server-selector-0.6.2.tgz",
-      "integrity": "sha512-LWszmRECZzs1oweMFIEs17D7x4Wox7phjiZwa/42H/Gq6x6uHTtZL0VwgJxzJ3pBWbNrAw1PpNcClznBih40aA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@api-components/api-server-selector/-/api-server-selector-0.6.3.tgz",
+      "integrity": "sha512-vqZRg64S3FFRbyDYqKOAaWac6JpL+M76oqbJwh8sJk7oiVP2FAZrpA1X1bVrWJ0MEmixxMwmIlzlwvNg8YVQ+w==",
       "dev": true,
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.2.2",
@@ -1074,7 +1074,7 @@
         "@anypoint-web-components/anypoint-input": "^0.2.14",
         "@anypoint-web-components/anypoint-item": "^1.0.5",
         "@anypoint-web-components/anypoint-listbox": "^1.0.4",
-        "@api-components/amf-helper-mixin": "^4.3.2",
+        "@api-components/amf-helper-mixin": "^4.3.4",
         "lit-element": "^2.3.1",
         "lit-html": "^1.2.1"
       }
@@ -1095,9 +1095,9 @@
       }
     },
     "@api-components/api-url": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@api-components/api-url/-/api-url-0.1.0.tgz",
-      "integrity": "sha512-MjEL+TFraa8jkVnaZW3lFNrIkoE4Zmr7UwU0m26jfCjIIBx92S18l2GsxJF61wHJoICIYGrTwXMIJU3Xfj+Imw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@api-components/api-url/-/api-url-0.1.1.tgz",
+      "integrity": "sha512-c+uy6X08uWW7a2I0q+lI448/bOAHYJRF9ek0siNbZB3NIpDQ3BeOGVco/4XparFp2R4umwU9I8gjjn95lpdSGQ==",
       "dev": true,
       "requires": {
         "@advanced-rest-client/arc-icons": "^3.2.2",
@@ -1107,7 +1107,7 @@
         "@anypoint-web-components/anypoint-input": "^0.2.23",
         "@anypoint-web-components/anypoint-switch": "^0.1.4",
         "@anypoint-web-components/validatable-mixin": "^1.1.3",
-        "@api-components/amf-helper-mixin": "^4.2.0",
+        "@api-components/amf-helper-mixin": "^4.3.4",
         "@api-components/api-forms": "^0.1.2",
         "lit-element": "^2.4.0",
         "lit-html": "^1.3.0"
@@ -1140,12 +1140,12 @@
       "integrity": "sha512-lWIjd8Wq6tYJmF8ZXyUgQdGq+vhXP7pKY/QcPQdKOn2IXb4/gqTglebtXnxjME41+uKSPQoMSKTEVT/PwX93qQ=="
     },
     "@babel/code-frame": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.10.4"
+        "@babel/highlight": "^7.12.13"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -1155,12 +1155,12 @@
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
+      "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.4",
+        "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -1185,21 +1185,6 @@
             "supports-color": "^5.3.0"
           }
         },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -1218,18 +1203,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
+      "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz",
-      "integrity": "sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.13.tgz",
+      "integrity": "sha512-8fSpqYRETHATtNitsCXq8QQbKJP31/KnDl2Wz2Vtui9nKzjss2ysuZtyVsWjBtvkeEFo346gkwjYPab1hvrXkQ==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
@@ -1274,6 +1259,21 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         }
       }
     },
@@ -1330,6 +1330,21 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         }
       }
     },
@@ -1341,6 +1356,14 @@
       "requires": {
         "@commitlint/types": "^11.0.0",
         "semver": "7.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        }
       }
     },
     "@commitlint/lint": {
@@ -1388,6 +1411,21 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         }
       }
     },
@@ -1419,15 +1457,15 @@
       },
       "dependencies": {
         "fs-extra": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
           "dev": true,
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
+            "universalify": "^2.0.0"
           }
         },
         "jsonfile": {
@@ -1438,20 +1476,12 @@
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
-          },
-          "dependencies": {
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-              "dev": true
-            }
           }
         },
         "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
         }
       }
@@ -1541,9 +1571,9 @@
       "dev": true
     },
     "@comunica/actor-abstract-bindings-hash": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-bindings-hash/-/actor-abstract-bindings-hash-1.18.1.tgz",
-      "integrity": "sha512-MlbUzTc05NUBaKqD7WzAusARPRWiAjyHaBiXKE3YQT0QOCdmCvcDQ26lvyXSJiQHb+tnHfMxDclC1Id3QC3nJQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-bindings-hash/-/actor-abstract-bindings-hash-1.19.2.tgz",
+      "integrity": "sha512-Rf5DH43+inBhI/IlmKILQGTYWCWWmK/s3YM+O/wmxO3M38OXFspv4fyIfUYrfBHeYKaq78w64vPH43umw+DOAQ==",
       "dev": true,
       "requires": {
         "canonicalize": "^1.0.1",
@@ -1553,15 +1583,15 @@
       }
     },
     "@comunica/actor-abstract-mediatyped": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.18.1.tgz",
-      "integrity": "sha512-pjAf0agOpADEVBKp11XhFGH33FML4LTxO08JJmr6Qf6FlbMAhU3KFBrK34nYZ/5QNdhZwE2i8eFmjNC/2CbOKA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.19.2.tgz",
+      "integrity": "sha512-BER87Niq4dqLxfF3JtYCZ1lCHB+MB/N3yNUq5GnInzdisAQBT/T7dwmps1eqF435DyiDS/j0VOJpnPmWV8bRlA==",
       "dev": true
     },
     "@comunica/actor-abstract-path": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.18.1.tgz",
-      "integrity": "sha512-WGRRvpdkGFytDZUdLZrd/r81migly3OE+qcFzFmuk7Qucqr1a7Kq/WbcejqtdSgnvCfBGQTug0gpDW9bf8q6qQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.19.2.tgz",
+      "integrity": "sha512-0pqfYotFtXIDyNjmqqGyxrVwrS7pNY9R5he3PugilzZCOrHy19Zr8bofr24xTXgEP8VdQR1uD2vE1H43JE/6HA==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -1572,9 +1602,9 @@
       }
     },
     "@comunica/actor-http-memento": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.18.1.tgz",
-      "integrity": "sha512-QfhTsenZj4No6BfGKNe+gjA07wtLcTKLua8MaaprPxK6aN/xwdodOyz0Fj/bTZ1On4ixsozbFKNPGFMaB9vNVQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.19.2.tgz",
+      "integrity": "sha512-3d8cviX1i1CKXkaV0u0C9S/jzmViZTMd3kwVUOwaqJW8EH4dpJkADtxaly32qtRfUp2suNQ/dcG8DlAcHUPNNg==",
       "dev": true,
       "requires": {
         "@types/parse-link-header": "^1.0.0",
@@ -1583,9 +1613,9 @@
       }
     },
     "@comunica/actor-http-native": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.18.1.tgz",
-      "integrity": "sha512-nQ7dlB3GkP46h28XVyOi43Q4fuc1pUaYWFz6YQeTOgyJMnm/fgNvu9ECsFdG4rYVo3377VVxpvCylGx936S+wQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.19.2.tgz",
+      "integrity": "sha512-/eLeL3/MCuoTpYqMKM4f6VNIgBMtduOHc7DHxw/p6I/mL9mRZp848+MyhKFEN4W4gVk8aKVlMCI4MI52bKXWLw==",
       "dev": true,
       "requires": {
         "@types/parse-link-header": "^1.0.0",
@@ -1595,122 +1625,122 @@
       }
     },
     "@comunica/actor-http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-1.18.1.tgz",
-      "integrity": "sha512-waZ8XeXA+A734fIqx8K0MW+9R3Meb+CyRzAKsVf9OQxDlRoCSD3jovpoLMz9L3Cc+4Qb4RuTn/ddw1vFy1pW0Q==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-1.19.2.tgz",
+      "integrity": "sha512-b/yP6TbpEBOac5gtX+4lxF6cd+/mI0WQiYUZGhRQZ2gUEcU0js0Gte9uqz1wCVxIQJnMbOryso3tCVFw/CZNJg==",
       "dev": true
     },
     "@comunica/actor-init-sparql": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.18.1.tgz",
-      "integrity": "sha512-5MYRw4/bgXxo9WKw6xlbUBHMjyNAEyaq9XT2O+WlkX67vORqzC/HE5PFdr65Qg9nSdSby6hspnsu6D2xJ1aHuQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.19.2.tgz",
+      "integrity": "sha512-TUYde50lcJOVbIkY+sJb9B1OuaKB8yvy8oyeNXF8nF3rOdFT0hnjmPcyT9KRKKJXmG7t4ywygDSbyaGqPnlyUA==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.18.1",
-        "@comunica/actor-abstract-mediatyped": "^1.18.1",
-        "@comunica/actor-http-memento": "^1.18.1",
-        "@comunica/actor-http-native": "^1.18.1",
-        "@comunica/actor-http-proxy": "^1.18.1",
-        "@comunica/actor-optimize-query-operation-join-bgp": "^1.18.1",
-        "@comunica/actor-query-operation-ask": "^1.18.1",
-        "@comunica/actor-query-operation-bgp-empty": "^1.18.1",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.18.1",
-        "@comunica/actor-query-operation-bgp-single": "^1.18.1",
-        "@comunica/actor-query-operation-construct": "^1.18.1",
-        "@comunica/actor-query-operation-describe-subject": "^1.18.1",
-        "@comunica/actor-query-operation-distinct-hash": "^1.18.1",
-        "@comunica/actor-query-operation-extend": "^1.18.1",
-        "@comunica/actor-query-operation-filter-sparqlee": "^1.18.1",
-        "@comunica/actor-query-operation-from-quad": "^1.18.1",
-        "@comunica/actor-query-operation-group": "^1.18.1",
-        "@comunica/actor-query-operation-join": "^1.18.1",
-        "@comunica/actor-query-operation-leftjoin-left-deep": "^1.18.1",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.18.1",
-        "@comunica/actor-query-operation-minus": "^1.18.1",
-        "@comunica/actor-query-operation-orderby-sparqlee": "^1.18.1",
-        "@comunica/actor-query-operation-path-alt": "^1.18.1",
-        "@comunica/actor-query-operation-path-inv": "^1.18.1",
-        "@comunica/actor-query-operation-path-link": "^1.18.1",
-        "@comunica/actor-query-operation-path-nps": "^1.18.1",
-        "@comunica/actor-query-operation-path-one-or-more": "^1.18.1",
-        "@comunica/actor-query-operation-path-seq": "^1.18.1",
-        "@comunica/actor-query-operation-path-zero-or-more": "^1.18.1",
-        "@comunica/actor-query-operation-path-zero-or-one": "^1.18.1",
-        "@comunica/actor-query-operation-project": "^1.18.1",
-        "@comunica/actor-query-operation-quadpattern": "^1.18.1",
-        "@comunica/actor-query-operation-reduced-hash": "^1.18.1",
-        "@comunica/actor-query-operation-service": "^1.18.1",
-        "@comunica/actor-query-operation-slice": "^1.18.1",
-        "@comunica/actor-query-operation-sparql-endpoint": "^1.18.1",
-        "@comunica/actor-query-operation-union": "^1.18.1",
-        "@comunica/actor-query-operation-values": "^1.18.1",
-        "@comunica/actor-rdf-dereference-http-parse": "^1.18.1",
-        "@comunica/actor-rdf-join-multi-smallest": "^1.18.1",
-        "@comunica/actor-rdf-join-nestedloop": "^1.18.1",
-        "@comunica/actor-rdf-join-symmetrichash": "^1.18.1",
-        "@comunica/actor-rdf-metadata-all": "^1.18.1",
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.18.1",
-        "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.18.1",
-        "@comunica/actor-rdf-metadata-extract-sparql-service": "^1.18.1",
-        "@comunica/actor-rdf-metadata-primary-topic": "^1.18.1",
-        "@comunica/actor-rdf-parse-html": "^1.18.1",
-        "@comunica/actor-rdf-parse-html-microdata": "^1.18.1",
-        "@comunica/actor-rdf-parse-html-rdfa": "^1.18.1",
-        "@comunica/actor-rdf-parse-html-script": "^1.18.1",
-        "@comunica/actor-rdf-parse-jsonld": "^1.18.1",
-        "@comunica/actor-rdf-parse-n3": "^1.18.1",
-        "@comunica/actor-rdf-parse-rdfxml": "^1.18.1",
-        "@comunica/actor-rdf-parse-xml-rdfa": "^1.18.1",
-        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^1.18.1",
-        "@comunica/actor-rdf-resolve-hypermedia-none": "^1.18.1",
-        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.18.1",
-        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^1.18.1",
-        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.18.1",
-        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.18.1",
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.18.1",
-        "@comunica/actor-rdf-serialize-jsonld": "^1.18.1",
-        "@comunica/actor-rdf-serialize-n3": "^1.18.1",
-        "@comunica/actor-sparql-parse-algebra": "^1.18.1",
-        "@comunica/actor-sparql-parse-graphql": "^1.18.1",
-        "@comunica/actor-sparql-serialize-json": "^1.18.1",
-        "@comunica/actor-sparql-serialize-rdf": "^1.18.1",
-        "@comunica/actor-sparql-serialize-simple": "^1.18.1",
-        "@comunica/actor-sparql-serialize-sparql-csv": "^1.18.1",
-        "@comunica/actor-sparql-serialize-sparql-json": "^1.18.1",
-        "@comunica/actor-sparql-serialize-sparql-tsv": "^1.18.1",
-        "@comunica/actor-sparql-serialize-sparql-xml": "^1.18.1",
-        "@comunica/actor-sparql-serialize-stats": "^1.18.1",
-        "@comunica/actor-sparql-serialize-table": "^1.18.1",
-        "@comunica/actor-sparql-serialize-tree": "^1.18.1",
-        "@comunica/bus-context-preprocess": "^1.18.1",
-        "@comunica/bus-http": "^1.18.1",
-        "@comunica/bus-http-invalidate": "^1.18.1",
-        "@comunica/bus-init": "^1.18.1",
-        "@comunica/bus-optimize-query-operation": "^1.18.1",
-        "@comunica/bus-query-operation": "^1.18.1",
-        "@comunica/bus-rdf-dereference": "^1.18.1",
-        "@comunica/bus-rdf-dereference-paged": "^1.18.1",
-        "@comunica/bus-rdf-join": "^1.18.1",
-        "@comunica/bus-rdf-metadata": "^1.18.1",
-        "@comunica/bus-rdf-metadata-extract": "^1.18.1",
-        "@comunica/bus-rdf-parse": "^1.18.1",
-        "@comunica/bus-rdf-parse-html": "^1.18.1",
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.18.1",
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.18.1",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.18.1",
-        "@comunica/bus-rdf-serialize": "^1.18.1",
-        "@comunica/bus-sparql-parse": "^1.18.1",
-        "@comunica/bus-sparql-serialize": "^1.18.1",
-        "@comunica/core": "^1.18.1",
-        "@comunica/logger-pretty": "^1.18.1",
-        "@comunica/logger-void": "^1.18.1",
-        "@comunica/mediator-all": "^1.18.1",
-        "@comunica/mediator-combine-pipeline": "^1.18.1",
-        "@comunica/mediator-combine-union": "^1.18.1",
-        "@comunica/mediator-number": "^1.18.1",
-        "@comunica/mediator-race": "^1.18.1",
-        "@comunica/runner": "^1.18.1",
-        "@comunica/runner-cli": "^1.18.1",
+        "@comunica/actor-abstract-bindings-hash": "^1.19.2",
+        "@comunica/actor-abstract-mediatyped": "^1.19.2",
+        "@comunica/actor-http-memento": "^1.19.2",
+        "@comunica/actor-http-native": "^1.19.2",
+        "@comunica/actor-http-proxy": "^1.19.2",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^1.19.2",
+        "@comunica/actor-query-operation-ask": "^1.19.2",
+        "@comunica/actor-query-operation-bgp-empty": "^1.19.2",
+        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.19.2",
+        "@comunica/actor-query-operation-bgp-single": "^1.19.2",
+        "@comunica/actor-query-operation-construct": "^1.19.2",
+        "@comunica/actor-query-operation-describe-subject": "^1.19.2",
+        "@comunica/actor-query-operation-distinct-hash": "^1.19.2",
+        "@comunica/actor-query-operation-extend": "^1.19.2",
+        "@comunica/actor-query-operation-filter-sparqlee": "^1.19.2",
+        "@comunica/actor-query-operation-from-quad": "^1.19.2",
+        "@comunica/actor-query-operation-group": "^1.19.2",
+        "@comunica/actor-query-operation-join": "^1.19.2",
+        "@comunica/actor-query-operation-leftjoin-left-deep": "^1.19.2",
+        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.19.2",
+        "@comunica/actor-query-operation-minus": "^1.19.2",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^1.19.2",
+        "@comunica/actor-query-operation-path-alt": "^1.19.2",
+        "@comunica/actor-query-operation-path-inv": "^1.19.2",
+        "@comunica/actor-query-operation-path-link": "^1.19.2",
+        "@comunica/actor-query-operation-path-nps": "^1.19.2",
+        "@comunica/actor-query-operation-path-one-or-more": "^1.19.2",
+        "@comunica/actor-query-operation-path-seq": "^1.19.2",
+        "@comunica/actor-query-operation-path-zero-or-more": "^1.19.2",
+        "@comunica/actor-query-operation-path-zero-or-one": "^1.19.2",
+        "@comunica/actor-query-operation-project": "^1.19.2",
+        "@comunica/actor-query-operation-quadpattern": "^1.19.2",
+        "@comunica/actor-query-operation-reduced-hash": "^1.19.2",
+        "@comunica/actor-query-operation-service": "^1.19.2",
+        "@comunica/actor-query-operation-slice": "^1.19.2",
+        "@comunica/actor-query-operation-sparql-endpoint": "^1.19.2",
+        "@comunica/actor-query-operation-union": "^1.19.2",
+        "@comunica/actor-query-operation-values": "^1.19.2",
+        "@comunica/actor-rdf-dereference-http-parse": "^1.19.2",
+        "@comunica/actor-rdf-join-multi-smallest": "^1.19.2",
+        "@comunica/actor-rdf-join-nestedloop": "^1.19.2",
+        "@comunica/actor-rdf-join-symmetrichash": "^1.19.2",
+        "@comunica/actor-rdf-metadata-all": "^1.19.2",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.19.2",
+        "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.19.2",
+        "@comunica/actor-rdf-metadata-extract-sparql-service": "^1.19.2",
+        "@comunica/actor-rdf-metadata-primary-topic": "^1.19.2",
+        "@comunica/actor-rdf-parse-html": "^1.19.2",
+        "@comunica/actor-rdf-parse-html-microdata": "^1.19.2",
+        "@comunica/actor-rdf-parse-html-rdfa": "^1.19.2",
+        "@comunica/actor-rdf-parse-html-script": "^1.19.2",
+        "@comunica/actor-rdf-parse-jsonld": "^1.19.2",
+        "@comunica/actor-rdf-parse-n3": "^1.19.2",
+        "@comunica/actor-rdf-parse-rdfxml": "^1.19.2",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^1.19.2",
+        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^1.19.2",
+        "@comunica/actor-rdf-resolve-hypermedia-none": "^1.19.2",
+        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.19.2",
+        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^1.19.2",
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.19.2",
+        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.19.2",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.19.2",
+        "@comunica/actor-rdf-serialize-jsonld": "^1.19.2",
+        "@comunica/actor-rdf-serialize-n3": "^1.19.2",
+        "@comunica/actor-sparql-parse-algebra": "^1.19.2",
+        "@comunica/actor-sparql-parse-graphql": "^1.19.2",
+        "@comunica/actor-sparql-serialize-json": "^1.19.2",
+        "@comunica/actor-sparql-serialize-rdf": "^1.19.2",
+        "@comunica/actor-sparql-serialize-simple": "^1.19.2",
+        "@comunica/actor-sparql-serialize-sparql-csv": "^1.19.2",
+        "@comunica/actor-sparql-serialize-sparql-json": "^1.19.2",
+        "@comunica/actor-sparql-serialize-sparql-tsv": "^1.19.2",
+        "@comunica/actor-sparql-serialize-sparql-xml": "^1.19.2",
+        "@comunica/actor-sparql-serialize-stats": "^1.19.2",
+        "@comunica/actor-sparql-serialize-table": "^1.19.2",
+        "@comunica/actor-sparql-serialize-tree": "^1.19.2",
+        "@comunica/bus-context-preprocess": "^1.19.2",
+        "@comunica/bus-http": "^1.19.2",
+        "@comunica/bus-http-invalidate": "^1.19.2",
+        "@comunica/bus-init": "^1.19.2",
+        "@comunica/bus-optimize-query-operation": "^1.19.2",
+        "@comunica/bus-query-operation": "^1.19.2",
+        "@comunica/bus-rdf-dereference": "^1.19.2",
+        "@comunica/bus-rdf-dereference-paged": "^1.19.2",
+        "@comunica/bus-rdf-join": "^1.19.2",
+        "@comunica/bus-rdf-metadata": "^1.19.2",
+        "@comunica/bus-rdf-metadata-extract": "^1.19.2",
+        "@comunica/bus-rdf-parse": "^1.19.2",
+        "@comunica/bus-rdf-parse-html": "^1.19.2",
+        "@comunica/bus-rdf-resolve-hypermedia": "^1.19.2",
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^1.19.2",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.19.2",
+        "@comunica/bus-rdf-serialize": "^1.19.2",
+        "@comunica/bus-sparql-parse": "^1.19.2",
+        "@comunica/bus-sparql-serialize": "^1.19.2",
+        "@comunica/core": "^1.19.2",
+        "@comunica/logger-pretty": "^1.19.2",
+        "@comunica/logger-void": "^1.19.2",
+        "@comunica/mediator-all": "^1.19.2",
+        "@comunica/mediator-combine-pipeline": "^1.19.2",
+        "@comunica/mediator-combine-union": "^1.19.2",
+        "@comunica/mediator-number": "^1.19.2",
+        "@comunica/mediator-race": "^1.19.2",
+        "@comunica/runner": "^1.19.2",
+        "@comunica/runner-cli": "^1.19.2",
         "@types/minimist": "^1.2.0",
         "@types/rdf-js": "*",
         "asynciterator": "^3.0.3",
@@ -1724,89 +1754,89 @@
       }
     },
     "@comunica/actor-init-sparql-rdfjs": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql-rdfjs/-/actor-init-sparql-rdfjs-1.18.1.tgz",
-      "integrity": "sha512-AelBSYfYltkvuARPd79zikmLKBmJk3WLhxmWH1Bdlb7kp7VLeT8t+8XB5O0uHr/B+D3LJLHrz7/4a2iJUrFp1g==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql-rdfjs/-/actor-init-sparql-rdfjs-1.19.2.tgz",
+      "integrity": "sha512-8UWNPF5bCNRMigIJEK0rA9urmv2JTMz7PygB/ZZ2fGCGSuIJjdoeu+CGoQufqZSlloQpWooDqVxqPTGI1x+kuw==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.18.1",
-        "@comunica/actor-init-sparql": "^1.18.1",
-        "@comunica/actor-query-operation-ask": "^1.18.1",
-        "@comunica/actor-query-operation-bgp-empty": "^1.18.1",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.18.1",
-        "@comunica/actor-query-operation-bgp-single": "^1.18.1",
-        "@comunica/actor-query-operation-construct": "^1.18.1",
-        "@comunica/actor-query-operation-describe-subject": "^1.18.1",
-        "@comunica/actor-query-operation-distinct-hash": "^1.18.1",
-        "@comunica/actor-query-operation-extend": "^1.18.1",
-        "@comunica/actor-query-operation-filter-sparqlee": "^1.18.1",
-        "@comunica/actor-query-operation-from-quad": "^1.18.1",
-        "@comunica/actor-query-operation-join": "^1.18.1",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.18.1",
-        "@comunica/actor-query-operation-orderby-sparqlee": "^1.18.1",
-        "@comunica/actor-query-operation-path-alt": "^1.18.1",
-        "@comunica/actor-query-operation-path-inv": "^1.18.1",
-        "@comunica/actor-query-operation-path-link": "^1.18.1",
-        "@comunica/actor-query-operation-path-nps": "^1.18.1",
-        "@comunica/actor-query-operation-path-one-or-more": "^1.18.1",
-        "@comunica/actor-query-operation-path-seq": "^1.18.1",
-        "@comunica/actor-query-operation-path-zero-or-more": "^1.18.1",
-        "@comunica/actor-query-operation-path-zero-or-one": "^1.18.1",
-        "@comunica/actor-query-operation-project": "^1.18.1",
-        "@comunica/actor-query-operation-quadpattern": "^1.18.1",
-        "@comunica/actor-query-operation-service": "^1.18.1",
-        "@comunica/actor-query-operation-slice": "^1.18.1",
-        "@comunica/actor-query-operation-union": "^1.18.1",
-        "@comunica/actor-query-operation-values": "^1.18.1",
-        "@comunica/actor-rdf-join-nestedloop": "^1.18.1",
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.18.1",
-        "@comunica/actor-rdf-serialize-jsonld": "^1.18.1",
-        "@comunica/actor-rdf-serialize-n3": "^1.18.1",
-        "@comunica/actor-sparql-parse-algebra": "^1.18.1",
-        "@comunica/actor-sparql-serialize-json": "^1.18.1",
-        "@comunica/actor-sparql-serialize-rdf": "^1.18.1",
-        "@comunica/actor-sparql-serialize-simple": "^1.18.1",
-        "@comunica/actor-sparql-serialize-sparql-json": "^1.18.1",
-        "@comunica/actor-sparql-serialize-sparql-xml": "^1.18.1",
-        "@comunica/bus-context-preprocess": "^1.18.1",
-        "@comunica/bus-init": "^1.18.1",
-        "@comunica/bus-query-operation": "^1.18.1",
-        "@comunica/bus-rdf-join": "^1.18.1",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.18.1",
-        "@comunica/bus-rdf-serialize": "^1.18.1",
-        "@comunica/bus-sparql-parse": "^1.18.1",
-        "@comunica/bus-sparql-serialize": "^1.18.1",
-        "@comunica/core": "^1.18.1",
-        "@comunica/mediator-combine-pipeline": "^1.18.1",
-        "@comunica/mediator-combine-union": "^1.18.1",
-        "@comunica/mediator-number": "^1.18.1",
-        "@comunica/mediator-race": "^1.18.1",
-        "@comunica/runner": "^1.18.1",
-        "@comunica/runner-cli": "^1.18.1"
+        "@comunica/actor-abstract-mediatyped": "^1.19.2",
+        "@comunica/actor-init-sparql": "^1.19.2",
+        "@comunica/actor-query-operation-ask": "^1.19.2",
+        "@comunica/actor-query-operation-bgp-empty": "^1.19.2",
+        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.19.2",
+        "@comunica/actor-query-operation-bgp-single": "^1.19.2",
+        "@comunica/actor-query-operation-construct": "^1.19.2",
+        "@comunica/actor-query-operation-describe-subject": "^1.19.2",
+        "@comunica/actor-query-operation-distinct-hash": "^1.19.2",
+        "@comunica/actor-query-operation-extend": "^1.19.2",
+        "@comunica/actor-query-operation-filter-sparqlee": "^1.19.2",
+        "@comunica/actor-query-operation-from-quad": "^1.19.2",
+        "@comunica/actor-query-operation-join": "^1.19.2",
+        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.19.2",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^1.19.2",
+        "@comunica/actor-query-operation-path-alt": "^1.19.2",
+        "@comunica/actor-query-operation-path-inv": "^1.19.2",
+        "@comunica/actor-query-operation-path-link": "^1.19.2",
+        "@comunica/actor-query-operation-path-nps": "^1.19.2",
+        "@comunica/actor-query-operation-path-one-or-more": "^1.19.2",
+        "@comunica/actor-query-operation-path-seq": "^1.19.2",
+        "@comunica/actor-query-operation-path-zero-or-more": "^1.19.2",
+        "@comunica/actor-query-operation-path-zero-or-one": "^1.19.2",
+        "@comunica/actor-query-operation-project": "^1.19.2",
+        "@comunica/actor-query-operation-quadpattern": "^1.19.2",
+        "@comunica/actor-query-operation-service": "^1.19.2",
+        "@comunica/actor-query-operation-slice": "^1.19.2",
+        "@comunica/actor-query-operation-union": "^1.19.2",
+        "@comunica/actor-query-operation-values": "^1.19.2",
+        "@comunica/actor-rdf-join-nestedloop": "^1.19.2",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.19.2",
+        "@comunica/actor-rdf-serialize-jsonld": "^1.19.2",
+        "@comunica/actor-rdf-serialize-n3": "^1.19.2",
+        "@comunica/actor-sparql-parse-algebra": "^1.19.2",
+        "@comunica/actor-sparql-serialize-json": "^1.19.2",
+        "@comunica/actor-sparql-serialize-rdf": "^1.19.2",
+        "@comunica/actor-sparql-serialize-simple": "^1.19.2",
+        "@comunica/actor-sparql-serialize-sparql-json": "^1.19.2",
+        "@comunica/actor-sparql-serialize-sparql-xml": "^1.19.2",
+        "@comunica/bus-context-preprocess": "^1.19.2",
+        "@comunica/bus-init": "^1.19.2",
+        "@comunica/bus-query-operation": "^1.19.2",
+        "@comunica/bus-rdf-join": "^1.19.2",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.19.2",
+        "@comunica/bus-rdf-serialize": "^1.19.2",
+        "@comunica/bus-sparql-parse": "^1.19.2",
+        "@comunica/bus-sparql-serialize": "^1.19.2",
+        "@comunica/core": "^1.19.2",
+        "@comunica/mediator-combine-pipeline": "^1.19.2",
+        "@comunica/mediator-combine-union": "^1.19.2",
+        "@comunica/mediator-number": "^1.19.2",
+        "@comunica/mediator-race": "^1.19.2",
+        "@comunica/runner": "^1.19.2",
+        "@comunica/runner-cli": "^1.19.2"
       }
     },
     "@comunica/actor-optimize-query-operation-join-bgp": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.18.1.tgz",
-      "integrity": "sha512-4W9zkiUdENs0oy9natFr7OFHeneNz5XxPfWnBcKFAvx99anMvrwPp0zTtbu2pEmZaavu+xS96cmYB7+f1d4gTQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.19.2.tgz",
+      "integrity": "sha512-MyC//Cl9SwQNKQeaULea8ViU1ehn68hL6CuqqwDHL/0M6lLi45aMFUBs9iK/Vw330uzFjbLjTc1epo1fFb2tLA==",
       "dev": true,
       "requires": {
         "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-ask": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-1.18.1.tgz",
-      "integrity": "sha512-B0fliw0Lk9qMRrTLYeGsT+hpKNbygivvLF/jZ0sUby5yF4HkVT3hZuuz2zdKjIwFKmqkXDPuHA+K2M0rqXMlGQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-1.19.2.tgz",
+      "integrity": "sha512-ogRkDwuPxDBRV8By20OHSkB89MblNM4YVfkMT2pPDhWrPojKGQVvedi58LpnfWX1NmTN63fhm9F8TyaG+jwsew==",
       "dev": true,
       "requires": {
         "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-bgp-empty": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-empty/-/actor-query-operation-bgp-empty-1.18.1.tgz",
-      "integrity": "sha512-QeG7TvHs7e+zYMOSDXRkFV+FhZAUSYAwVkN/BA2H5RD539QOneOE3ucPU+iui3b20fJE1FC3BpRpvJFpRg0++A==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-empty/-/actor-query-operation-bgp-empty-1.19.2.tgz",
+      "integrity": "sha512-Lbv7XC1Jct0FMIat4ZwVH73M2KttaSKbiVCN27ef97HTlveHS5IJ0TXUBcf/sn3YGXhQcaF9zFiLozZ9cD7o0g==",
       "dev": true,
       "requires": {
         "asynciterator": "^3.0.3",
@@ -1816,9 +1846,9 @@
       }
     },
     "@comunica/actor-query-operation-bgp-left-deep-smallest": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.18.1.tgz",
-      "integrity": "sha512-4A2giRgzsQUBnxaMBe7ksGxxnrGnoKcqxw67nOQCbeGA28Tyro16tWnll0dKkP9eQNb2ssy521ecOL+I5WBAtA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.19.2.tgz",
+      "integrity": "sha512-KuyPkY47MFBYcZIwE2shJYTpd1ERGOLuwEVG3UOXz/ON6tosklQOAbuGHe0bFk0fZTrM2e3SLVdPMeWaetf7QA==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -1829,18 +1859,18 @@
       }
     },
     "@comunica/actor-query-operation-bgp-single": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-single/-/actor-query-operation-bgp-single-1.18.1.tgz",
-      "integrity": "sha512-XUkjrPoBKxnoNwAdWoUo5RgsdLi7pgYKfu1VD3pQl2lg9tYBNYlxOXTaOpeJeAqqVmtWuJlTt4QX8kDhD9iMjg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-single/-/actor-query-operation-bgp-single-1.19.2.tgz",
+      "integrity": "sha512-Z9mdfGg/blqzh9wDEusnwwpTpP7Eb3GdbIOAxaMzIe3fo3PDuTadariXPzliho9tprC1dF/JN78i/1QM5MYqUA==",
       "dev": true,
       "requires": {
         "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-construct": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-1.18.1.tgz",
-      "integrity": "sha512-onpgJcq2zeCixTe0UCqkNr3vSCNPNUl1VCgCwT+E68J87/ShTa+Pr6E4icHJTwPNgkBDiRMbweF89upzS7LcyQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-1.19.2.tgz",
+      "integrity": "sha512-wNktY1yUVFCQBqvcr4xD52hlMmDzrB0VOJ9aEHQdvjmCs4P2AsLCG5Ty+qiz7va3HC1nT1qV4qRNLkeUYS93GQ==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -1851,12 +1881,12 @@
       }
     },
     "@comunica/actor-query-operation-describe-subject": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-1.18.1.tgz",
-      "integrity": "sha512-v5lMT9BEwq1wP8JvVHJcs0p1WY5/V7zqy01oiASYdJklc5N0Vj94m+44hb9f0V2khtKAJmDqSpEaGph18wiCUg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-1.19.2.tgz",
+      "integrity": "sha512-AVNiPI/k6HM+fSRxcTodsHLld+lADxzKDnjUGk4ckcWSqVsmzwlWUJ1DZfp8xqVj/3uWkIeG1oaY8h5Ph15ssg==",
       "dev": true,
       "requires": {
-        "@comunica/actor-query-operation-union": "^1.18.1",
+        "@comunica/actor-query-operation-union": "^1.19.2",
         "@types/rdf-js": "*",
         "asynciterator": "^3.0.3",
         "rdf-data-factory": "^1.0.3",
@@ -1864,19 +1894,19 @@
       }
     },
     "@comunica/actor-query-operation-distinct-hash": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-1.18.1.tgz",
-      "integrity": "sha512-JIqgeIv808BuUTmu9Dx2PD+dL3N2cX2s3dMTZrkYmxtZfb09qbj1W+VbEhsflYFN7DndfiMKl6+2hOEa4xA+JA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-1.19.2.tgz",
+      "integrity": "sha512-LO+hAW0tGRthAUKOkUM7ODjIsUbdNgPh+3cdVr4vkb2OcI/bJy1i5owIKUotepg8SuwekjDgOz0DxF2Mr5rjtw==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.18.1",
+        "@comunica/actor-abstract-bindings-hash": "^1.19.2",
         "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-extend": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.18.1.tgz",
-      "integrity": "sha512-vkkQAeOpTm49TEcCqAg3MIa8m+kxBHXuxU/UvYm+y5+eyH97jvNiYK6BtarCgZcSVXQ3PYKS5sW/b4nVL5ydMg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.19.2.tgz",
+      "integrity": "sha512-6n2vY/QvOc4QreT3I/yf8jVryJgOo6czAGL/UelqS00BO/uOwRK1TjUsylGzeCTtp0w0j7SF6UiCp3PueIAi5g==",
       "dev": true,
       "requires": {
         "rdf-string": "^1.5.0",
@@ -1885,9 +1915,9 @@
       }
     },
     "@comunica/actor-query-operation-filter-sparqlee": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.18.1.tgz",
-      "integrity": "sha512-Ku2nEWbnzQ2d1bG8qS7iYJT4N4qRkMP63A5LWDWs6veYP+bvMhVn2bP8Wahg88Q/KvKBa6WQOWKkc8RmvyqHbw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.19.2.tgz",
+      "integrity": "sha512-J+YZ8jzgpXVuKOJt1wEXiu5ZuynvSJ7USVqPbv3rqgmA86cXKL/ko5JNf6aT3kGIkHsxmXHtxKYfZ0xv0g07HA==",
       "dev": true,
       "requires": {
         "sparqlalgebrajs": "^2.4.0",
@@ -1895,9 +1925,9 @@
       }
     },
     "@comunica/actor-query-operation-from-quad": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.18.1.tgz",
-      "integrity": "sha512-380vmQCMVcsS3+qby7lVkgp3iBhmZelGm+kRNXrBkJPD9dR4zB3/AjgNEVpEOJxxtR/5po9V41899Yud/M/PiA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.19.2.tgz",
+      "integrity": "sha512-bao1/9lBBOHTnkORdfxpRrvvxHoJGEBTH06/E5CQPod7SkVlYs4cSBqy8UikkqNpehoXXHgQsOzncue8vlu2rQ==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -1905,12 +1935,12 @@
       }
     },
     "@comunica/actor-query-operation-group": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-1.18.1.tgz",
-      "integrity": "sha512-cLWvlbAVww0SfNX2pT8BUJcosKS1zcb2Y655ymGiYyxfVksiDPoApvghMzSxgZpfSnED4bWwlJJ1kkqDhPSpWA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-1.19.2.tgz",
+      "integrity": "sha512-1h32gBva2Dd1SIbnhoEQizCzQkhRxI4r0lotDTtiijF/Wl/yvqc4FSaJ5ieeEVKSlPLpxmAvRKiGoGVT1FxA5A==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.18.1",
+        "@comunica/actor-abstract-bindings-hash": "^1.19.2",
         "asynciterator": "^3.0.3",
         "rdf-string": "^1.5.0",
         "sparqlalgebrajs": "^2.4.0",
@@ -1918,30 +1948,30 @@
       }
     },
     "@comunica/actor-query-operation-join": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-1.18.1.tgz",
-      "integrity": "sha512-41+trHjLvLc1RrrapconECLEWggZAhURFVXD/L3HWatmRTq71WlV7JdsSFMrZkDpHNNgRvUna1AvjCuaGlvowQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-1.19.2.tgz",
+      "integrity": "sha512-va0/UJyVojEDnmXON16zre5i6zhX1bFPeA0MmndTMxVaUSHPpknZkRq1VnSKxE6jb8bejVEfjgcU9JxRnPd+uQ==",
       "dev": true,
       "requires": {
         "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-leftjoin-left-deep": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-left-deep/-/actor-query-operation-leftjoin-left-deep-1.18.1.tgz",
-      "integrity": "sha512-qcGFFeuzgDJEOR1Tcei2oLXS+dm5R6gikcHWpAEVgapP2Ia2AySW2lKHcV62xPVnVkwXd0OcLw3JDPHXYmKTwg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-left-deep/-/actor-query-operation-leftjoin-left-deep-1.19.2.tgz",
+      "integrity": "sha512-j3Ah5oz+K6m3Tj+mBLK5qt20BKnMimEOKy1WNic/Z48CshJU8lH/jCivTOrg/AYjx3+5fi4JfsKEVY/o8olHyA==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-join": "^1.18.1",
+        "@comunica/bus-rdf-join": "^1.19.2",
         "@types/rdf-js": "*",
         "asynciterator": "^3.0.3",
         "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-leftjoin-nestedloop": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.18.1.tgz",
-      "integrity": "sha512-e67UxQXodEVK0LZDSyKJg+0v2tcsbAEHjCywlHRzRdKPls4KuxhvT0Mj2vt5SHQ01rR5evNvaYA4BNB+n2BH4g==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.19.2.tgz",
+      "integrity": "sha512-KYG+3HeBzzY2INVHERMvaCjuymxjfHvrmfmhrjidWzHsjyaEefaDKaZcp6zIRBGRKmHsN/+03c6cVm7ZMru7wg==",
       "dev": true,
       "requires": {
         "asynciterator": "^3.0.3",
@@ -1950,12 +1980,12 @@
       }
     },
     "@comunica/actor-query-operation-minus": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-1.18.1.tgz",
-      "integrity": "sha512-icRsegxaRjXk6fd4eXRmGH7qUtzB5snld2LxoD4yFu/kSbOKupPJJZQjMcR/KkNNuHR+o+lo8B+PS5hJ7HUPYw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-1.19.2.tgz",
+      "integrity": "sha512-UdsMEUzjEyLI7Zz9uAAcRwdQgFXNpKA7Kr/9T8bIC65Ta3g1r2WmOm6Bf/NIeAaoB0gMTm/vZObj2Ey5+OSIWg==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.18.1",
+        "@comunica/actor-abstract-bindings-hash": "^1.19.2",
         "@types/rdf-js": "*",
         "asynciterator": "^3.0.3",
         "rdf-string": "^1.5.0",
@@ -1963,9 +1993,9 @@
       }
     },
     "@comunica/actor-query-operation-orderby-sparqlee": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.18.1.tgz",
-      "integrity": "sha512-Qk2PQYQ0RkZ2K4SIRYoz5+fwG7exXV/wY06eAXIXxmlD0fviTF6bYlUr3h238VV0QhYMjsRrdcSPmT2MnVl5kQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.19.2.tgz",
+      "integrity": "sha512-jB9UE+wmOPvZl00BjzuRKv38/4iXcExhhgSB8UetG0XM2jmaz68XjJwHHOntoAD+XO6jyKR/cIIriVYTMfu7JQ==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -1976,53 +2006,53 @@
       }
     },
     "@comunica/actor-query-operation-path-alt": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.18.1.tgz",
-      "integrity": "sha512-BBIQ5oYr/1mLmZXxevLbRvjzLHbrUyZlFG22jx/8fk51ikAynyAGkV4EHi0TJs7+Zy0RuFwfVccOnscL7bWURQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.19.2.tgz",
+      "integrity": "sha512-5Lqtt5qfnkJx+vL0g7rZAXoA4wEWCjSmkhTLWdZU+4+YvXhfY0S3aQ8W1Ik/Q93O5u+pRFje1z49AMpWuk83MQ==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.18.1",
+        "@comunica/actor-abstract-path": "^1.19.2",
         "asynciterator": "^3.0.3",
         "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-path-inv": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.18.1.tgz",
-      "integrity": "sha512-Ezdl8bcjOkv2t8rjG0MU/CeJYcxQR7mUmMN8bvLebHQlUp95OgZ34yiwMCVBLWkn7xycD1Rzqq4Nk33zs8P3Rw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.19.2.tgz",
+      "integrity": "sha512-R4FJAQAMkIqTNxX4aLxvkx2UeQXGbBle6kWNC9z9LiOaBorXERw22xTOlG9viNkn+3iRPVCIcxJyJ+Lw+msTTw==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.18.1"
+        "@comunica/actor-abstract-path": "^1.19.2"
       }
     },
     "@comunica/actor-query-operation-path-link": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.18.1.tgz",
-      "integrity": "sha512-yTQwxyBt0xuq0QEhJdPB6GFyoyUkRC7C76oXtdw1ocJV48NPBfHVeQ6AjQR6S6mcWA6LvUQd1oUj5pwe4AU+zw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.19.2.tgz",
+      "integrity": "sha512-+efbj6CH81KFXt4oy4PXM23HoOSj9SEvxPG+l4zmpnrjzsoGgpBT21bZeqwuGUYnCXmqCkljjMvEv7w0UwfA9w==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.18.1",
+        "@comunica/actor-abstract-path": "^1.19.2",
         "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-path-nps": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.18.1.tgz",
-      "integrity": "sha512-52qzXYVRR7y4DeR5MNzoN9ahpvTICSx7U9pQGczX5be52bc0keyQsmUf3ReOApuK2Ru700GmAiu5sXYW7+5JOw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.19.2.tgz",
+      "integrity": "sha512-j2R31+DtnDjWpzY6SNv7xezCzhQ3HuGLuAnwqpy22wQgLSev7D8jbe/1NSl9GTQZL62MnF39JrHLc0bSQwXWQw==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.18.1",
+        "@comunica/actor-abstract-path": "^1.19.2",
         "rdf-string": "^1.5.0",
         "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-path-one-or-more": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.18.1.tgz",
-      "integrity": "sha512-CFekd04zUrjuALf+zEkGiRD0+z1R0uFIX2b0PxQ8bkXWfBf4AcsgaUU3TKZwTt5LsXcCvUQ4Opm6miYV7Yr25Q==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.19.2.tgz",
+      "integrity": "sha512-0c2EjNb7gSwyRxD6VMhqefrm3trOAVePIxWui7Dc0R8/Y50s9rZAmM9C2Yv+8V8eRgJdqPpZrDa6ck+CWLnrUA==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.18.1",
+        "@comunica/actor-abstract-path": "^1.19.2",
         "@types/rdf-js": "*",
         "asynciterator": "^3.0.3",
         "rdf-string": "^1.5.0",
@@ -2030,44 +2060,44 @@
       }
     },
     "@comunica/actor-query-operation-path-seq": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.18.1.tgz",
-      "integrity": "sha512-NKKM970D65XWyzw6am5B/WQKeNg7p3BHZHCAlokwyicJK4kHwEivT8/5TkUdZk3pGpmKCN4dGTHwKzTmNFoifw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.19.2.tgz",
+      "integrity": "sha512-rGuTL2JsbwXVsplIhrZgbilmpeirDTBXOETkPJHcwsVtZV6MBZGNfVTK36V6bHUJXQAZJpukLuuO27SaUMwVqg==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.18.1",
+        "@comunica/actor-abstract-path": "^1.19.2",
         "rdf-string": "^1.5.0",
         "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-path-zero-or-more": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.18.1.tgz",
-      "integrity": "sha512-PrSJ39sSUELTDz5gOIfueJNqaiNHJTx5Ou5QsVs1VPNduvgmMUPu93+0SUGPo3qPC3UEkN/tu7XVo5aq9DaH8Q==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.19.2.tgz",
+      "integrity": "sha512-cJI7xCyb1j9VLeyEnGtOfNOi7yvIbJ+Zm7eztG/jHRgBWEKDfVrVhlSKrctMvZjFzvbZBiYuMdrCE+56mXydSA==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.18.1",
+        "@comunica/actor-abstract-path": "^1.19.2",
         "asynciterator": "^3.0.3",
         "rdf-string": "^1.5.0",
         "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-path-zero-or-one": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.18.1.tgz",
-      "integrity": "sha512-+oqEZtNn9XC4WSJkA18zouH4Wl5NhMujFEBDNG3Ga3FuZC87TmIGi93AUBaYOMGexocoajhNJLM4N3RyRuCQHw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.19.2.tgz",
+      "integrity": "sha512-r/hn3jUVWHExyICMyeobVvyrVIvZAB7SpB00nO1r1xx/JdJdUAlPP72oKioX8UcKcT5WVt1D3b3+6ZFwaQKz1w==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-path": "^1.18.1",
+        "@comunica/actor-abstract-path": "^1.19.2",
         "asynciterator": "^3.0.3",
         "rdf-string": "^1.5.0",
         "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-project": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-1.18.1.tgz",
-      "integrity": "sha512-FW6rtWaaAPtwB3Z4PlnBtaumqNOCEoecBriDdZ49tZHWiEL7sadBkbAPhDr01z0DEazaWKiBzyk+rBqN+XXWOw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-1.19.2.tgz",
+      "integrity": "sha512-u3X3Vc9Sj/s5LgrFoymaFXc6fyI6XAO7XQRVpO+1F5jKmY+oFQwK/jRi6J6JluTZNtjlmzfIyY0EsHoRSMnPfw==",
       "dev": true,
       "requires": {
         "@comunica/data-factory": "^1.17.0",
@@ -2077,9 +2107,9 @@
       }
     },
     "@comunica/actor-query-operation-quadpattern": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.18.1.tgz",
-      "integrity": "sha512-qk1Bcwd4QkEOXl0yf6QnBxtOl9Q3K70lcoUDjknPO9ArBZrXADvVaRqhTck/aoEIkAziPKCtwR8Va9txEx42zw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.19.2.tgz",
+      "integrity": "sha512-LAKMVsaMJP1uZUl8aFWnFg1pbhIwu4b+CRvIj0hHf7iaC1ng6wwRLIDF7c/6gDlzsDD9BRZg0r0XmJQPF0/DFg==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -2090,32 +2120,32 @@
       }
     },
     "@comunica/actor-query-operation-reduced-hash": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.18.1.tgz",
-      "integrity": "sha512-epk4IP2XTf6V97o2XNH1wmEOac8JCR6eb+HyvPhhmzeu+YixmgQ3AX4s8KmRLZUKc+zfBf6+tKErQvXXQCfYhA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.19.2.tgz",
+      "integrity": "sha512-owHWzME+V9uhsJrdU7jKJCWh4wfGrGL+iuf+wlFvbSp8Z2EZdRYAtymAvItCmFzVeTTGlPlff89xdWqg/apxLA==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.18.1",
+        "@comunica/actor-abstract-bindings-hash": "^1.19.2",
         "@types/lru-cache": "^5.1.0",
         "lru-cache": "^6.0.0",
         "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-service": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-1.18.1.tgz",
-      "integrity": "sha512-IvolDGGrc2qJXk5XlBBVtKe1rF5s5zhIXU5bNd3RlqpNr1vtLjPylrgQ7a/gvlt4BzaD5GwV5zprnIXWoK+ptQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-1.19.2.tgz",
+      "integrity": "sha512-YA4T/dO09HecfNri8JRveg6hRst79Wfb5dZqmBshj4zh/zzZFABDWI+XMXbwbX6wuG1q7wJDCRzO2Ku3X1WV6A==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.18.1",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.19.2",
         "asynciterator": "^3.0.3",
         "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/actor-query-operation-slice": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-1.18.1.tgz",
-      "integrity": "sha512-GjdJ+PUAByWI0InogOqh22IKJ3qV7lVB1TwCzwSMeQdY+67TU0dx7V2PtEGSvWEgw8OId0GBQ0e+isi8I6vT1w==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-1.19.2.tgz",
+      "integrity": "sha512-Cq+uBRQKzbOa5uJUCP7O00lyPQ6TtYn2dOT+5VCdnjAbuk3DyVqR614tih3SAgA5LRYTUxfX+WePlvOoIq6eRA==",
       "dev": true,
       "requires": {
         "asynciterator": "^3.0.3",
@@ -2123,13 +2153,13 @@
       }
     },
     "@comunica/actor-query-operation-sparql-endpoint": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.18.1.tgz",
-      "integrity": "sha512-YcLSSTmou73kLOlM5P+Lug31sQf3X3T7WtADy8ZF99GLxTh3Sx1anluN0q6Ngn7P472K/G8Ab0fX1xj9fg5gdg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.19.2.tgz",
+      "integrity": "sha512-VC4VLMA9zAckci3S/Smw2ebQe0JJoDB1La/EcSidI1RJNittlf5fw79wbCYGxZuTi0tCmTCYRyarMqDZpQrp7Q==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.18.1",
-        "@comunica/utils-datasource": "^1.18.1",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.19.2",
+        "@comunica/utils-datasource": "^1.19.2",
         "@types/rdf-js": "*",
         "arrayify-stream": "^1.0.0",
         "asynciterator": "^3.0.3",
@@ -2140,9 +2170,9 @@
       }
     },
     "@comunica/actor-query-operation-union": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-1.18.1.tgz",
-      "integrity": "sha512-IA+QsPDsPdVjFKNPd5sKcaEwqa1KT3WlONiUWpvpy8kUzDW8MnVHvg9ffVJ8DX1nqiijOJBj7aJr6w5Ejb2iAg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-1.19.2.tgz",
+      "integrity": "sha512-4swo5gN/XzqPIPEzw2rf5EsbB7jqywS56pjz1R4zt9ar1vHGgsiwkngEM6iWfWkrFbZF/gUnSQMIo/F9oLtPPg==",
       "dev": true,
       "requires": {
         "asynciterator": "^3.0.3",
@@ -2150,9 +2180,9 @@
       }
     },
     "@comunica/actor-query-operation-values": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-1.18.1.tgz",
-      "integrity": "sha512-BzjqvYNi6pqHZFDKBZTjeVtoCBDX/c8Jf/1L3taOUgjT7M7ZpO3RXebMlLzXd8a0UgqPGLlW2VEwto4PUi38LQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-1.19.2.tgz",
+      "integrity": "sha512-JZfuffeWhX/Ss6FDeQBR+H/OtCh/iI4nl+ElFRjfJ8OfHU/r5cU7R5ecXb+U0cZ780/PltgfKyq6wtannRYnLg==",
       "dev": true,
       "requires": {
         "asynciterator": "^3.0.3",
@@ -2161,9 +2191,9 @@
       }
     },
     "@comunica/actor-rdf-dereference-http-parse": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.18.1.tgz",
-      "integrity": "sha512-Pu8sGAcmuJicFK09piXpvDtRvLV8A7FCwhrgSv1vjZPhiorSrav1ihVQaVAVmthp8mJepXh1ZmOWJVn7+cwQGA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.19.2.tgz",
+      "integrity": "sha512-2/b6YgILmYf+tR5GZ/3JRGxY9xqExVJnaRx6qOJ3ay/98MRRjhQxtDxAIClMZNFlc+gwJb1T5vPoX1H8dnfDNg==",
       "dev": true,
       "requires": {
         "cross-fetch": "^3.0.5",
@@ -2171,46 +2201,46 @@
       }
     },
     "@comunica/actor-rdf-join-multi-smallest": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-multi-smallest/-/actor-rdf-join-multi-smallest-1.18.1.tgz",
-      "integrity": "sha512-80Od3BHbwSdqpTF3Fj13FSvvc8k/76jeAO90FI1iRuE9ppKjTEtg/4CqOyoORKs8gHiQIywSiH4BsnSYMZEIxQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-multi-smallest/-/actor-rdf-join-multi-smallest-1.19.2.tgz",
+      "integrity": "sha512-Vr2ZwBsKRY3TMRta+AI009zrdk+1pUrgsyw4kUQmQ4EbzJQ1VfoUQ8sg23A8rDNAIcBdq+1skHRhWOxfPAvaiw==",
       "dev": true,
       "requires": {
-        "@comunica/bus-query-operation": "^1.18.1",
-        "@comunica/mediatortype-iterations": "^1.18.1"
+        "@comunica/bus-query-operation": "^1.19.2",
+        "@comunica/mediatortype-iterations": "^1.19.2"
       }
     },
     "@comunica/actor-rdf-join-nestedloop": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-nestedloop/-/actor-rdf-join-nestedloop-1.18.1.tgz",
-      "integrity": "sha512-EmLKcIM1ZYwzOXZFEZ2TQRKf1ERmBPkiNuZf+ZFEFhtFO7PrBMVjmvfs426vE0d40rNnxZdMxCMb9BQQp+87ag==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-nestedloop/-/actor-rdf-join-nestedloop-1.19.2.tgz",
+      "integrity": "sha512-Rt7FJ8s+HMMiY3F4qoXL4/WX0JGEFktfFv6o2OZyTrJ+T+CRYhw/ikQX0upVZpdT0xqjGxRzAZbdVfyAezHyNQ==",
       "dev": true,
       "requires": {
         "asyncjoin": "^1.0.1"
       }
     },
     "@comunica/actor-rdf-join-symmetrichash": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-symmetrichash/-/actor-rdf-join-symmetrichash-1.18.1.tgz",
-      "integrity": "sha512-HPXGmzqsc2SDtfmJ76fREdejb0rbk7KsDDWHBTLDvqi/JR8BD1xzhf0e6NmQf5oZYyPlNNOnpsTWruFeuE7Ung==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-symmetrichash/-/actor-rdf-join-symmetrichash-1.19.2.tgz",
+      "integrity": "sha512-uXgh74oDrbEqflgUzEadwKu/X4EARZUPkLkHSyHgTVkwwlr2uNhvNmve931nXjt0OBZ80THiVEcYit4roHd8LA==",
       "dev": true,
       "requires": {
         "asyncjoin": "^1.0.1"
       }
     },
     "@comunica/actor-rdf-metadata-all": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-1.18.1.tgz",
-      "integrity": "sha512-XLdUMWnq7rnnb+wqqnCVmrscwohJvB8cfQsw9Px8aQFON3cIcn8jqeaKsTE3HAtJGP0JwHhYdGVpoBwMkS3vVg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-1.19.2.tgz",
+      "integrity": "sha512-2oTtZOUFs2PyILht0J6Ma9/x5srjyvijbobgCSfcrENkv+r1wRDriyHMOfiuWLlvFlksumJ17gerp8iehPorqQ==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-rdf-metadata-extract-hydra-controls": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-1.18.1.tgz",
-      "integrity": "sha512-kw2UIbdKVenu1wYxFlxANjkfsAO8cDFANtJWUyg2WTBrNv5l+hO88w1YHBuhiweBB4yQQ0GyI6HlEyjWNt5UFA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-1.19.2.tgz",
+      "integrity": "sha512-3Qt7NhG0AJUnDM7537G8lyryPdykpdIqGERs0EEPzvfOtiCbPXoBtvVfj82hdIcIXKEgqrpgyt4CuJoGGSK6zQ==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -2219,73 +2249,73 @@
       }
     },
     "@comunica/actor-rdf-metadata-extract-hydra-count": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-1.18.1.tgz",
-      "integrity": "sha512-tobQNXfl+tgRcyfYjPmyCSSj3m5cAUQGIoJMVkRD6UxqGUpsIKJ73X1fUwtitDqfA8tXDcNF0dtAqxQcS5E4TA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-1.19.2.tgz",
+      "integrity": "sha512-7sD2BNiyDhjjUmavmy0xUX0EgI5DNacKUa8xX5xzZj5WC/glKtSFMO/nUpiqzosmdaZ3vryICm4mXVFS3eKmRA==",
       "dev": true
     },
     "@comunica/actor-rdf-metadata-extract-sparql-service": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-1.18.1.tgz",
-      "integrity": "sha512-ZspKJqpd/1dTRv9IQOpBn6rb+BF7T6ErWkyZBN6tfLDVbSCtDQLBr9guVVCxPeEvxIfx+jCJi1sZ1tqauPqGlQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-1.19.2.tgz",
+      "integrity": "sha512-hVr1RPf+kryRkDGVwK1DX3mwskVtJhDI8Jhr5u2Y0CmtvelucNpo8mivvNgV5M5M4FhX+4jSUp17ndnJTizHUw==",
       "dev": true,
       "requires": {
         "relative-to-absolute-iri": "^1.0.5"
       }
     },
     "@comunica/actor-rdf-metadata-primary-topic": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-1.18.1.tgz",
-      "integrity": "sha512-16UMt95xL+IvYBAPd+9JeABrWeDdYHbm53QeNnQfspXhv27aMZvrn+l13hp2dozuS2MYe9PCmfIQIFzo4z+AxA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-1.19.2.tgz",
+      "integrity": "sha512-mh50SL2p5+eo9CbNJOysUe0C7ThoA8x5Y8994Plo3p/c0HfT2G8KsTM/vyIYIkKr54lDZ7I8izmd41dDicJ49w==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-rdf-parse-html": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-1.18.1.tgz",
-      "integrity": "sha512-Wx5c/4bN7ohJjsp397JeX8YTDZXMp3VWEFilIjl4/CtAoGV4BzYlHPFo3ZCuRjRpn2EPyJF0Itxedio0b30u3A==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-1.19.2.tgz",
+      "integrity": "sha512-E7eJH5CR9cvYoaK78OwA8wkc46FsU7hbDHIkXy3fKktooXOcOJxoMU3+0xZ0n6qFRRzMQjzNzh+KnR+0ZgZWIg==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-parse-html": "^1.18.1",
+        "@comunica/bus-rdf-parse-html": "^1.19.2",
         "@types/rdf-js": "*",
-        "htmlparser2": "^5.0.0"
+        "htmlparser2": "^6.0.0"
       }
     },
     "@comunica/actor-rdf-parse-html-microdata": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-1.18.1.tgz",
-      "integrity": "sha512-ErW0ngwOnEXbGr2fskQYBvau1ZsvB3IbQimAcNAx9m+pIeoDF51+qjpTTZpcckgbTN9wUsNfGCwxk9jbKH2nTQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-1.19.2.tgz",
+      "integrity": "sha512-i+FfdPRsd1wT5yrnFORo1eFbL2G+YyeG3dQtC7bEuTf3pW9wXJCUWarLZ0dBbCK3WaPR+J+zdM+fss4j++0bNA==",
       "dev": true,
       "requires": {
         "microdata-rdf-streaming-parser": "^1.1.0"
       }
     },
     "@comunica/actor-rdf-parse-html-rdfa": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-1.18.1.tgz",
-      "integrity": "sha512-c1ae+6F+ohTIAscItsVI/+dKY5tKx7sJwKrrznwgXoPlkFxk7aI9W03Du8X1FsT+spNlk3+CIA/lUPrZ53Lhhw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-1.19.2.tgz",
+      "integrity": "sha512-Sx9vDZwHnXbcAkKOTQj0mIeablIQO1W6O92Vl1u0eStuaMyB2xBIFnPDpHpM9oQ8Yg14xwdGnSfqfCRW1Ar/mQ==",
       "dev": true,
       "requires": {
         "rdfa-streaming-parser": "^1.4.0"
       }
     },
     "@comunica/actor-rdf-parse-html-script": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-1.18.1.tgz",
-      "integrity": "sha512-KI3h3Qb+/IibzFJjLWYVFn43pM0oyRaDovm9VzyGass4wbxmMUVm69lgOLTEcsmOVmTPNcvNI4dYa03g/zjwjA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-1.19.2.tgz",
+      "integrity": "sha512-GgJF1cZpFWJ7ga3g/BxuxpPQeASf07eZd3TiLRlQ5Mll4sVVqU9CO+oebQXbtnzJYnxPrSP85YCP9Ez9TnfFkQ==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-parse-html": "^1.18.1",
+        "@comunica/bus-rdf-parse-html": "^1.19.2",
         "@types/rdf-js": "*",
         "relative-to-absolute-iri": "^1.0.5"
       }
     },
     "@comunica/actor-rdf-parse-jsonld": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.18.1.tgz",
-      "integrity": "sha512-3X3REVIqRTgjzWUsfVgJQsyZ75J/SSl7mHfFchNncxRdm14hq67RApO0gztdSLj4t4Kv1HtciEm/zs+nEuKmNw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.19.2.tgz",
+      "integrity": "sha512-t2rLKtiUV0ku0ZkxjzIDUfPV/SOfeYmdR6DRBDMM/b44xda+fxeSIsYEsxjNMsz0GWUppgWi/+dmBbioO38qDQ==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -2295,9 +2325,9 @@
       }
     },
     "@comunica/actor-rdf-parse-n3": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.18.1.tgz",
-      "integrity": "sha512-5GQ+PaabjXSgu3mR8tN2ZWyy+pSaq6rIyHDNKAbh3AkG70j6tQWxfa4OZIk2+ImDEjtPVofYsJZnY5VSZhZEwg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.19.2.tgz",
+      "integrity": "sha512-IReAuHq1H0xNOMO0fd1mbbkgnfw1VS/Q5+hK0WJA3j5lII/nrSKRIbmdyP6jYLNHwj2F3i6aGTCRr9Z75/86kA==",
       "dev": true,
       "requires": {
         "@types/n3": "^1.4.4",
@@ -2305,47 +2335,47 @@
       }
     },
     "@comunica/actor-rdf-parse-rdfxml": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.18.1.tgz",
-      "integrity": "sha512-qCn8UovKW6xNCoYgR13MBPi8mOOSorRxPLpSOt7eVFEADFMkjzVJAbyExN+8EzHgrJj2DIwQixD2kYnGaEkz+Q==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.19.2.tgz",
+      "integrity": "sha512-vC4RVTe6RTsRD32ZJR5NEOUGiHACCVvlO2/NUFy3g9/H6aQdiKen/iAqfDo03jq4yJO2UTFx8zj5l5fLvzL9yA==",
       "dev": true,
       "requires": {
         "rdfxml-streaming-parser": "^1.4.0"
       }
     },
     "@comunica/actor-rdf-parse-xml-rdfa": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-1.18.1.tgz",
-      "integrity": "sha512-99g5zw57ZbxSKiv0daZiEWhu70Efs0dqKQsf4hIHl+1mZJ7gjYdXrA1gSb2h/bnvezZKyiqjkc9VxzD+J7dv0A==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-1.19.2.tgz",
+      "integrity": "sha512-y9dYBawjAxBfHZw3ITByq/+N/pkLmIqUcXc9ypiQEx1C2iZvlkgKiShhYK7b/Qzvx8FXqfhXKRknup8/yZicww==",
       "dev": true,
       "requires": {
         "rdfa-streaming-parser": "^1.3.0"
       }
     },
     "@comunica/actor-rdf-resolve-hypermedia-links-next": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-1.18.1.tgz",
-      "integrity": "sha512-PV7OGjCe5PDXO1xkJq96z6KHuLQF7+XB48MitkYcK80b5fNyzVK/RKUEwe9m99asZXg2GqTGtLmbzbUQ9XdYrg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-1.19.2.tgz",
+      "integrity": "sha512-VhtNZmQMwphmEukNOC+RyNHY0DXpC7pqRQ7wNFC310y1emRUuvHCuA2fMyKkbBJe1Hm5tOt60inqAudYMz/eew==",
       "dev": true
     },
     "@comunica/actor-rdf-resolve-hypermedia-none": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-1.18.1.tgz",
-      "integrity": "sha512-8lZLGyZGLF1XjhXwmOlGMD9xsFfc69YD1gh2elUeSTRF2F9xMFc0ynBqMQZ12CaNPK2k2/dRljMhLsvkGHK/Sg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-1.19.2.tgz",
+      "integrity": "sha512-Apur7/rfUdTn/O91ojGP2F4ZOwGzyHhv1rvg2AFbWUDsRIWu51AGur4/FVytRygR2QY14ZQf5DJu3gwRjeH5SA==",
       "dev": true,
       "requires": {
-        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.18.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.19.2",
         "@types/rdf-js": "*",
         "rdf-store-stream": "^1.0.1"
       }
     },
     "@comunica/actor-rdf-resolve-hypermedia-qpf": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-1.18.1.tgz",
-      "integrity": "sha512-tAK6qh91gohbOUF6/NyNrL2qFl3wV0PtoryJRfGGRO4GYEHK358hkSh0bfwjq/MXeQIyzogllk2xyPPv69fT6g==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-1.19.2.tgz",
+      "integrity": "sha512-FTPmc3UNcq70a1CJyre5XzyhausfnvWGeAEtnfi+ML7GD+xFZ0MM/lHEqdMHGakX1d7M3F9+muLetaS/zz+0HA==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-dereference": "^1.18.1",
+        "@comunica/bus-rdf-dereference": "^1.19.2",
         "@types/rdf-js": "*",
         "asynciterator": "^3.0.3",
         "rdf-data-factory": "^1.0.3",
@@ -2354,14 +2384,14 @@
       }
     },
     "@comunica/actor-rdf-resolve-hypermedia-sparql": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-1.18.1.tgz",
-      "integrity": "sha512-ifLBrxcBw3Pw5Y+wxdswnnvblquKdGH24evsXiZuhkbBCR7Lazubqdty7q25P4nZ6yQIzQpFBbwVa+J5zVwwfw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-1.19.2.tgz",
+      "integrity": "sha512-jXpEiZU6Fc2/qHHEhpRwbIeU4sAPGQuP7fzlLvdmatbk78iI6l+G/u32R3tl0Vi/qETxi5Hhnr37v30msdqWXg==",
       "dev": true,
       "requires": {
-        "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": "^1.18.1",
-        "@comunica/bus-query-operation": "^1.18.1",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.18.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": "^1.19.2",
+        "@comunica/bus-query-operation": "^1.19.2",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.19.2",
         "@types/rdf-js": "*",
         "asynciterator": "^3.0.3",
         "rdf-data-factory": "^1.0.3",
@@ -2370,9 +2400,9 @@
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-federated": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.18.1.tgz",
-      "integrity": "sha512-rKCVHcRs1ZIVDDg68i+6bSoYkJXsBMXyUX22TLmx7AUWgNk/LuhRbSKoujXkiemnqPycK/eJhT+MfP95nbBDGg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.19.2.tgz",
+      "integrity": "sha512-7txxy/D2//uMBQh204Oqfe3YfS2U9r+ftHvHWT+uVi+M4DX5kx7gO5LrhSl4KjqkjMUj9XicU2ZUWQbXsjkkJA==",
       "dev": true,
       "requires": {
         "@comunica/data-factory": "^1.17.0",
@@ -2384,14 +2414,14 @@
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-1.18.1.tgz",
-      "integrity": "sha512-tCkzY0wRy1NFp+d9jE0G4fPNvRq5VPOexU8WFXWeY1AILApOJ5SDi4FdsM9dfq+Iey6Bx+diw8WmuHF+zHFlag==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-1.19.2.tgz",
+      "integrity": "sha512-RI5LYX18R74QQYPIeMyeXXlvrIzLFGPSFr6JCvuNDXlYsiq9ilL/5AePv1TsuLIgyxixK2N4KzAyZ0hO1maAdQ==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-metadata": "^1.18.1",
-        "@comunica/bus-rdf-metadata-extract": "^1.18.1",
-        "@comunica/utils-datasource": "^1.18.1",
+        "@comunica/bus-rdf-metadata": "^1.19.2",
+        "@comunica/bus-rdf-metadata-extract": "^1.19.2",
+        "@comunica/utils-datasource": "^1.19.2",
         "@types/lru-cache": "^5.1.0",
         "@types/rdf-js": "*",
         "asynciterator": "^3.0.3",
@@ -2403,9 +2433,9 @@
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-1.18.1.tgz",
-      "integrity": "sha512-XvSRjeBuq0TsdjzmAq+9g9QlVB8fS8XBmBOgu60NSoDR3h1SDQK1A2T6B8CHvX9CtX0o8Xcx9MH5rbrw+FUhug==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-1.19.2.tgz",
+      "integrity": "sha512-+kTCV2So+GUoRxdSsYjuks2i2HjsfjXlzCKK0uYRGLXLmqUozf0zHh1ZfIZqdxDAFMwYiaTgPw2P9+MjICBYUw==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -2413,9 +2443,9 @@
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/-/actor-rdf-resolve-quad-pattern-sparql-json-1.18.1.tgz",
-      "integrity": "sha512-wXtKCutF9dedgMSLk4R0ionaio9ZSg6yCN7nEdrcF9pFbOnW5ItrdNH59aDpJT6MDFXTglcgyKoee6y/fDTDfw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/-/actor-rdf-resolve-quad-pattern-sparql-json-1.19.2.tgz",
+      "integrity": "sha512-XuNdqnDp2PegpZg6/9gs3V9XXmouQWTiD5yLBdFs55y+hUs+Y8ditaVXjqxfi7nCZhb+seqKupeWbDPQgOLpeg==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -2427,18 +2457,18 @@
       }
     },
     "@comunica/actor-rdf-serialize-jsonld": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.18.1.tgz",
-      "integrity": "sha512-kKzg0a0oEy8ESg9Thv9sVg0gEdGILPv6tXB4eJToPlSb9W03xSfUS7wA12/59xAncCmnhDyfRgpAzXWHAlcxlg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.19.2.tgz",
+      "integrity": "sha512-JHrJcT6TeyUbs4JniOioTK8fNcvWCFbIvuAQnOKJQySVn4Y+spflui7eopp0xlTVzAqXQ1RXwhfO+pM9HIaM4g==",
       "dev": true,
       "requires": {
         "jsonld-streaming-serializer": "^1.2.0"
       }
     },
     "@comunica/actor-rdf-serialize-n3": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-1.18.1.tgz",
-      "integrity": "sha512-0DelCUSdjWnd6i21yCfQ6b8e2HX/fkupXh534xByjZTiOj8LlRr+memE7LM2IOUx8GgGMn6fK0cZi+edT10q/g==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-1.19.2.tgz",
+      "integrity": "sha512-ZEsh1OVAUNbpUdybEqnc0eWQvQG8XekVkWhExIfOsRNIz3wm/echO62pXJqc5vILTP1d+dk5I0KkgibhPKQMMA==",
       "dev": true,
       "requires": {
         "@types/n3": "^1.4.4",
@@ -2448,9 +2478,9 @@
       }
     },
     "@comunica/actor-sparql-parse-algebra": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.18.1.tgz",
-      "integrity": "sha512-us7rpHgqj+bfZ2Ac9ObqcRUi4rKEeH30pk7ZcPeDuQLzcha8dCr8QetqUL3vl94TpYuG9KhkBLRJuTGjIPjvkw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.19.2.tgz",
+      "integrity": "sha512-P0LT4AtTYUjlmMh+mPAjhDs4rdebmbiExJtKoyVnVB1zeb4jhz/PlcxxcKslk1SWCEYYggcgTky5IM4XexZ/yQ==",
       "dev": true,
       "requires": {
         "@types/sparqljs": "^3.0.0",
@@ -2460,18 +2490,18 @@
       }
     },
     "@comunica/actor-sparql-parse-graphql": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.18.1.tgz",
-      "integrity": "sha512-CxXzNbSixjLPOJFKK7tjz+KRizX4/LAdVP2yx3JUx67FYmXO4UCz5D+8s1MQTbk+QrQvV2lmAzAz60Iw58Rp2w==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.19.2.tgz",
+      "integrity": "sha512-F8VnaH9fkLf2bRNfgsRfuvGLr6WBEgDrQ7WhYr17eYKDlEcb3S0fm8iCgjdde7j6jk7K+fGn5MoiorM4Koqpzg==",
       "dev": true,
       "requires": {
         "graphql-to-sparql": "^2.2.0"
       }
     },
     "@comunica/actor-sparql-serialize-json": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-json/-/actor-sparql-serialize-json-1.18.1.tgz",
-      "integrity": "sha512-C30LwcuGoomvrFQHzxnSn4NhWyy+98+yvVtzidIYzoOlZFF2mNiTLb6IRYM5cXKk8cy7i82fuOamr8EJEzVEMA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-json/-/actor-sparql-serialize-json-1.19.2.tgz",
+      "integrity": "sha512-YQ/Zd1Z+2am3uG42M/R65nag9KajJREyhr4Nq4ABIQqt1f6JDHV7ccyxo1mU8S+sRKsakjB3uUmRb+8A790ceA==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -2479,54 +2509,54 @@
       }
     },
     "@comunica/actor-sparql-serialize-rdf": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-rdf/-/actor-sparql-serialize-rdf-1.18.1.tgz",
-      "integrity": "sha512-3UU7ozaXovG8Wn35MPcOg7lPsqFw2CdR45HOkxCJ/9jLHGeVajMRFJdQNbexQwnYgAq++BanpPMzU8VD4uUUQA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-rdf/-/actor-sparql-serialize-rdf-1.19.2.tgz",
+      "integrity": "sha512-eTWm77j1j0gTacajE/W51lT4CKL+x6rRvfTkRnrKNkyCuVZd/j8gIT1f82Yf6K4TqxO6LJ6VwFFXF3sxx6nVmQ==",
       "dev": true
     },
     "@comunica/actor-sparql-serialize-simple": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.18.1.tgz",
-      "integrity": "sha512-kj7z/SXw99a0zLteU8zuLNjqNXsMCGMSgsbWRCls/BS/fxuN0JgJWXoKikXHhPLCV/lL5bSGVXnM6I6ROHfdUQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.19.2.tgz",
+      "integrity": "sha512-OwCWS25PxcskYd0V0GMVJEXb7GQzGZufN2fBYSpodtl98rTiCbC3c7sMShoqCm79GkuHhNLOjT6hLcJCFettAQ==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-sparql-serialize-sparql-csv": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-csv/-/actor-sparql-serialize-sparql-csv-1.18.1.tgz",
-      "integrity": "sha512-F3m735pDV9patpi3NSDRe7Zsu7l8LHcwg2hyo9SNbka/gnsFQQjGX0avS/mXI1tPfXbzpYYRdfw3uyGm7X9X7Q==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-csv/-/actor-sparql-serialize-sparql-csv-1.19.2.tgz",
+      "integrity": "sha512-jYlWfAghrApzDF2YUR3gkLuBQ4qMeDUZDKnEimIFDGfN1IgQUrrkyeui6YEXEbDwd3tu171QjNsEr/5DZFmr/A==",
       "dev": true,
       "requires": {
-        "@comunica/bus-query-operation": "^1.18.1",
+        "@comunica/bus-query-operation": "^1.19.2",
         "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-sparql-serialize-sparql-json": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.18.1.tgz",
-      "integrity": "sha512-aMeRClMGwbeEpuuKXQN+nQr9n0M27uQgLvMSjQaNu9l5EXzm3TZX+TJe4OANIQSGhiQtP7Hb2agegBV9JFaZJg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.19.2.tgz",
+      "integrity": "sha512-va/hIXJnCPnex+bq8/MABQrM4TWB1FKGhUlrSKdaOpmNgMAbKr6ylPbO1XOtNcqLfwGK2phVvPbPipGjTJEllw==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-sparql-serialize-sparql-tsv": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-tsv/-/actor-sparql-serialize-sparql-tsv-1.18.1.tgz",
-      "integrity": "sha512-c6SYtiu2Ba7zIdzRnS+Q7TOZX6DeaS9vO8mMDRqqXf0oQytWpx2RQ9cUjY2eveF3RbZewwuSkN8sbLmHM2T2Hg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-tsv/-/actor-sparql-serialize-sparql-tsv-1.19.2.tgz",
+      "integrity": "sha512-J8AgOeWUGSi1xWVjz/pd5MPkZlbBoOVhWShEob4MuzOb8ZvOd1K3hCi8IA2ZGH2FE4TMJcryB5RK7PAEal42uw==",
       "dev": true,
       "requires": {
-        "@comunica/bus-query-operation": "^1.18.1",
+        "@comunica/bus-query-operation": "^1.19.2",
         "@types/rdf-js": "*",
         "rdf-string-ttl": "^1.1.0"
       }
     },
     "@comunica/actor-sparql-serialize-sparql-xml": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-xml/-/actor-sparql-serialize-sparql-xml-1.18.1.tgz",
-      "integrity": "sha512-EsRUrPOVGW4hrCfdq5ovk1Igp5+lXNNOQnX/hW840Zp3xcexzmXrIDI6d4qh0Z0Mex0Gw4q4dnQTXEcJHR5s7g==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-xml/-/actor-sparql-serialize-sparql-xml-1.19.2.tgz",
+      "integrity": "sha512-DDpmjaHX+BTkLmXlaNp++U3heIF08tV36jVaLqaV2OXTlg2sdMBL67Lupd2ZRv/lYSAnwwiTr+WFimMcnptQpQ==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -2535,18 +2565,18 @@
       }
     },
     "@comunica/actor-sparql-serialize-stats": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-stats/-/actor-sparql-serialize-stats-1.18.1.tgz",
-      "integrity": "sha512-YUS86F5HMuK9Ew+gvj+z1nbssOBQevPN2QKiejK+7K4dFnkiyuUjP9hGwU9Llm4/QzqPbw9EbGx6MzD7ECufkw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-stats/-/actor-sparql-serialize-stats-1.19.2.tgz",
+      "integrity": "sha512-NkrLai5Q8UEJCNYMK5/W5DGpVoSdIm8bBYrIY1ONfuS6keizROAE0Fz86yzmAxPSlVKZOoqCjCCaLemO7cAsIg==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*"
       }
     },
     "@comunica/actor-sparql-serialize-table": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-table/-/actor-sparql-serialize-table-1.18.1.tgz",
-      "integrity": "sha512-V8DIuQILpnUPsO3pQT+5AUdVf7nD10oBWQM4q0nXokYsLRah6UYxfj8f931tsp9sot3n5mlN5XIQ/47B5N/AAA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-table/-/actor-sparql-serialize-table-1.19.2.tgz",
+      "integrity": "sha512-gcMAXVmuatSc5COY7A4bIS/kxry4EvzIhdJ6upf5p0Z+TL65nWSsFPUvr2erRBWjl3rlDPFHfBmn2vTtggumFA==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -2554,9 +2584,9 @@
       }
     },
     "@comunica/actor-sparql-serialize-tree": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-tree/-/actor-sparql-serialize-tree-1.18.1.tgz",
-      "integrity": "sha512-W/aOVaalZHnTD0S0yEka/ieJXo2Ofj+BKnlL7Isi/IBnZA4pIuas7XdGK/JUl/DmBeQ1HyKM4Pt1N58JSzBolA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-tree/-/actor-sparql-serialize-tree-1.19.2.tgz",
+      "integrity": "sha512-PyYBxruXKVVVRTdkU1fGhddaT6FXLtBY0rAPbd/ve0V4Ddte6Ey8ZXlUlsuoo/xAR6N6e6yV9bfc+QZ9rdnpvA==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -2564,15 +2594,15 @@
       }
     },
     "@comunica/bus-context-preprocess": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-1.18.1.tgz",
-      "integrity": "sha512-Kk0xWo2dw/OM4HwWiQ263DloziHlWxvGWwNzp4gOzJjkVFF55ooHypfNrdJglCq6elG4bDZsjvqRkyYsKHRK9Q==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-1.19.2.tgz",
+      "integrity": "sha512-CNYFubbQeCnhf2ZsIqLC/0u3zF0tJwqhvMc3rF9qnHw3SWtttGsBQpYtaOZR3uR7FSVJvJqKV65qLedumQdOog==",
       "dev": true
     },
     "@comunica/bus-http": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.18.1.tgz",
-      "integrity": "sha512-ovEy1HEagq2cla3WSCLyrA6LGMsfNyc7sm9UBJUnaX4KnYlOoombibsCwqiJhGfvHHV019yFj1l7NDICF3ZD3Q==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.19.2.tgz",
+      "integrity": "sha512-dRvN7k/ZjHly+Dr+baanvHPP3MjZINE6j7Zp8TAvV2wq6KQaJhUWRSfAVbzw3AkSWy2txtC3zXUpTYGJYYiV3Q==",
       "dev": true,
       "requires": {
         "is-stream": "^2.0.0",
@@ -2580,30 +2610,30 @@
       }
     },
     "@comunica/bus-http-invalidate": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-1.18.1.tgz",
-      "integrity": "sha512-M0l7y0Vid+68DStc3DRhuWpJd7XqZh60OKbJfwSBeCp5ZOFhKcCjjcuOzPJC5fBzZg+7/O74U1xqXJGnYusX0A==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-1.19.2.tgz",
+      "integrity": "sha512-eekin3KzdJeTxwsaX3XJ31eoNfc13mN4KXSpn5Unuu5lo8VmM8+CQauA4sJqkUwjbSlFqny60QZlUOPYZ/wOeA==",
       "dev": true
     },
     "@comunica/bus-init": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.18.1.tgz",
-      "integrity": "sha512-eXIfQM4cl3dKwSd5GVt2lxcTxiSqxZZ/u8rjQeS/vncdRDfIAY7WS1qBHARUXEgeLRu5LX5W4Bq13TGwn+dkNQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.19.2.tgz",
+      "integrity": "sha512-SVIcKPSrPlHxrndsKX650ijrOPMyBdZZkDe/mLXUKNq7cSerdQZtP6w95u7/fnBwjwXOAMjPiyP3L07rD6KAcA==",
       "dev": true
     },
     "@comunica/bus-optimize-query-operation": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-1.18.1.tgz",
-      "integrity": "sha512-pOhLRHYnqGTKMcS0W0pHrG54LqsGpMfNXzoTftvZtn5WbsUh3BrV5jrJ5E6SIIcjtW9l0vN1cF19ze+Ofv/rUg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-1.19.2.tgz",
+      "integrity": "sha512-Y5CevNB+NYO+PHwTOOWCDYh9YF53BWZi0OFsX26HdqxnqODYSt56pYFMDozeb+OBWTX0NN68CH4QUCjvNSPJbg==",
       "dev": true,
       "requires": {
         "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/bus-query-operation": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-1.18.1.tgz",
-      "integrity": "sha512-ZNlywwaKh8tRHQFwDvSYqXoRjT0QYOiZANWZDpkw4orliGQZJUA8X95yYhf0JGOftY2FBzznKOZvFtYPXnqesA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-1.19.2.tgz",
+      "integrity": "sha512-s9vzwYcgaRuOGWUA1WDGcOO+j7pjB2Vf1bCOUR/4Xdoz795ev415q3qtSqQISvNVwj5LM4pk0mcXDHsISRDn2Q==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -2614,18 +2644,18 @@
       }
     },
     "@comunica/bus-rdf-dereference": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.18.1.tgz",
-      "integrity": "sha512-BvgD4YXpII7I1X23agOwj55lX2bz5RRNDlsX84yudQIFO8xj0QiX7LkDoZad4MnEfj06cxipERh3ZfLNbEYD+g==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.19.2.tgz",
+      "integrity": "sha512-vK73nWJh1xF5Br1NFNX0Lx8nF6NDwKwgMzxqIxOj/gOxUJgTFOaWm7/brYc38ITSrDfYOAmlL4p2bGMNkdfm2A==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*"
       }
     },
     "@comunica/bus-rdf-dereference-paged": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference-paged/-/bus-rdf-dereference-paged-1.18.1.tgz",
-      "integrity": "sha512-ezgTpvA5Rknh+lzyfS0hbMkbD/tpgonxMI6iCJrcGua/4X0d7dRwPTLtnDI3j8V7pK0tHEKTwR3vt2B2Utt1lw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference-paged/-/bus-rdf-dereference-paged-1.19.2.tgz",
+      "integrity": "sha512-wn/bLMxDeWVyuT9zbrpFPpO0DtWVSrTB4R0j+DLOM1mk2PiLqW1LaxCQoUQl6+yxf9kwM7DOnNDgCLb/PhKmlw==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -2633,9 +2663,9 @@
       }
     },
     "@comunica/bus-rdf-join": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-1.18.1.tgz",
-      "integrity": "sha512-5ZhoqsTp3G49pIQZD3lyeK6RSE8bRcYBzEty8YiN41CH77wWksx+AXhjCNtYsDtCadlftqzPw17PB+59P/nb7A==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-1.19.2.tgz",
+      "integrity": "sha512-2/W25J2UmCTj9J3Dy46DRZRVxyeyDDRt4LmNevdSyYSsp8RhhXHTWkqzhJQekgRK/AALofy3b6xWJTBpbfX7cQ==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -2643,18 +2673,18 @@
       }
     },
     "@comunica/bus-rdf-metadata": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-1.18.1.tgz",
-      "integrity": "sha512-sDBLK0pICbIlsH0AL9XLboDAZ9RVT02dgKB1+8BHOAM/4DsXVBJpQ9rUG2T3JjK60UMGhYr4+CQemRiXd7mGiw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-1.19.2.tgz",
+      "integrity": "sha512-4HlBnOMy6VgCCsVA4yNAGavE3fxEHJ3AUxMUQSfh3Si38Ww1fUp1BVo39vLMb/rbxfVyGMDWqfB31wHYXFjnHA==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*"
       }
     },
     "@comunica/bus-rdf-metadata-extract": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.18.1.tgz",
-      "integrity": "sha512-x0i2Egy0gmvMhS3j3OANHKN/a2/IBxXX+l16MdvNHFTNXaTjvRCSsMC6jdPkekg7L2oirPhPrg4E7g1oBRR8IA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.19.2.tgz",
+      "integrity": "sha512-yo8HR4oidch0x0teAtnyKE+NDE07l8GiiU2anmgHS+fkZ8NlBBpbwT780kjpeTfHm2XuJzDCiYJR7Lhnbj8HZQ==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -2665,45 +2695,45 @@
       }
     },
     "@comunica/bus-rdf-parse": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.18.1.tgz",
-      "integrity": "sha512-GNNCd1cEp+mjVeUG8eHI3u1x8+ic6MatHRET/ujMeouC0kI1jX31R57PoX9QWzopOx73tueI2i9E+5xLQDa29A==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.19.2.tgz",
+      "integrity": "sha512-tXTAWFHdmrZXmze9tWOyih0dgxaCL1qusJHIdtLW3Krt9BZhhUjPVckoHTFB+LSexmOEDHF91+WrkTwBxIDGpg==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.18.1",
+        "@comunica/actor-abstract-mediatyped": "^1.19.2",
         "@types/rdf-js": "*"
       }
     },
     "@comunica/bus-rdf-parse-html": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-1.18.1.tgz",
-      "integrity": "sha512-bV4N7ABCshWi0S4VliibGLtazYGiToVyeMqhFBMyl/v8IaPOW+2QbE4JfXcen8+ieHqonFt28W/x9gbh7VEZeA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-1.19.2.tgz",
+      "integrity": "sha512-TdhTZ7/UKQl75kndpHlIWHPQVxuRg2wbViEhQgvZBu7nyWR0F39Sh4A9iGhmdiwgZkQ8MdGIjQEdwbcSPtxN4w==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*"
       }
     },
     "@comunica/bus-rdf-resolve-hypermedia": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-1.18.1.tgz",
-      "integrity": "sha512-xxs4LITJFYFHoap2b4i2ijIAqqsmcb8nJdJn4xby0h6Lh+MCS0wJzM/bl+tVduT1TzBw4u6UCCmxBIj1ESwW0w==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-1.19.2.tgz",
+      "integrity": "sha512-BqQDrIIdIExA3pRmmxRrWc87XUpbbayL1OZf/eiXFa3qWgqmtUuhRtzom3BYO2Oy59yVcK7wZm/hMXQQX1aaAA==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.18.1",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.19.2",
         "@types/rdf-js": "*",
         "asynciterator": "^3.0.3"
       }
     },
     "@comunica/bus-rdf-resolve-hypermedia-links": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-1.18.1.tgz",
-      "integrity": "sha512-UEjgHl/GFvZyfiZYNzsagJ1IdBQGUzuEHwFx3QKg3YPocOF3+sBop1de4QEWJMbXWvHvtJJdYKZ9c3iMb6V46w==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-1.19.2.tgz",
+      "integrity": "sha512-mW2iarewZz3nuFagbvN04JDj9MHrP7QCT9h0B8gBot7fUibZtn2n6yJPK7LOJHaLditQ+8zOMoAH2SDwjakq/Q==",
       "dev": true
     },
     "@comunica/bus-rdf-resolve-quad-pattern": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.18.1.tgz",
-      "integrity": "sha512-J4rNLk9uk/anSnvgTuD/cVeUPlkJQtSiRfaYOn+AbK+kABdtvr8xNyIBcjAKVjeqQjE7gdd42Sbdo+IJ6f08lQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.19.2.tgz",
+      "integrity": "sha512-x2QeGGK6ktG/UJCx5nuJqLjxl1RizSdTS6biEzcO4ZtXZ+S2K03PCFKd1YgufLPWXtajr32WnKAvD//wpTO6mg==",
       "dev": true,
       "requires": {
         "@types/rdf-js": "*",
@@ -2712,37 +2742,37 @@
       }
     },
     "@comunica/bus-rdf-serialize": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.18.1.tgz",
-      "integrity": "sha512-HYXVGfggEP05IGJZHXzUBszPe/y8PPqbs8BfMafrB/20Rz3CJu9fiLVZmkWH3FcdcE7ihkw8Omc1PVdMuFP00A==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.19.2.tgz",
+      "integrity": "sha512-HrtI/6CZ4Oi2L9zvGJqFH3DABAHtW9EmhqLGispLoGSwPLUO79hPOnyZw9TjTaEYHnO5uI2tjacXQm1fd7BHNQ==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.18.1",
+        "@comunica/actor-abstract-mediatyped": "^1.19.2",
         "@types/rdf-js": "*"
       }
     },
     "@comunica/bus-sparql-parse": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-parse/-/bus-sparql-parse-1.18.1.tgz",
-      "integrity": "sha512-0fDpmOgOMtGxDFnwbXzjqXEP0iv7M7eDwHuDtM+ZIAAXzwD+wbd/2wqMj2JauVnI3Z6DlxNTilsi70amEgNfrQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-parse/-/bus-sparql-parse-1.19.2.tgz",
+      "integrity": "sha512-rFlVGxX2ThYGEdmTC9ZkV6rtxUF41ShuyrK89/n7lyRzJH8oBbXsjUwymG5oEEsYc3PWLTVirCQCnZvbT8VCeg==",
       "dev": true,
       "requires": {
         "sparqlalgebrajs": "^2.4.0"
       }
     },
     "@comunica/bus-sparql-serialize": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-serialize/-/bus-sparql-serialize-1.18.1.tgz",
-      "integrity": "sha512-F7XtYjYN2fWGjbolA6outKKzE2b4V28MfVtKuTIApYgq8GWWQu/2FZE0q681xyv2x26cFHMzqUsiqlGIliFoXg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-serialize/-/bus-sparql-serialize-1.19.2.tgz",
+      "integrity": "sha512-104o/7ya4+raft6Ofw/CXGa2LzJfZMLELyK0LOqXvDY1/VBT5KWwtZbsbRaWB90oX0hbvJAxun8f37XP00hCmQ==",
       "dev": true,
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.18.1"
+        "@comunica/actor-abstract-mediatyped": "^1.19.2"
       }
     },
     "@comunica/core": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.18.1.tgz",
-      "integrity": "sha512-wXLOu/Wkt0zUy6XwI4W7IaXkcLmEkxs0P/xWY3huMdG5ixvFxVlOz+EuKz5sNCpeGiqZsMON4I9YvgiUlnZv0Q==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.19.2.tgz",
+      "integrity": "sha512-BmUZiuCbR2T/sFlmKW6mRRBIH7hef2irNIB2nA3dDbRj5MyHVOEDDh0cJdbgMtWaHyM4m2Bw8gk8c63fQsfMPA==",
       "dev": true,
       "requires": {
         "immutable": "^3.8.2"
@@ -2758,79 +2788,90 @@
       }
     },
     "@comunica/logger-pretty": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-1.18.1.tgz",
-      "integrity": "sha512-x0MPfyFyvB51h5O82iNt958fgF1Jw2hOb9ex60XrkHeb+++Bpg83c3RuVmcGEtWGUndNydPgugeaz2zY/OEEkw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-1.19.2.tgz",
+      "integrity": "sha512-Vd206zfJGkYePIfa/InY83VVd5VPx/tfwdq7brAPQjL668W8UPsfVBHwvib1/unTB1cDvp0Xv76MigjfwMZ1XA==",
       "dev": true
     },
     "@comunica/logger-void": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-1.18.1.tgz",
-      "integrity": "sha512-IHZL2KLagkJ3g+yQ1Bi34HTe9F1pN4cKXQQUuJdl0mSyPV1nAjlexXOU33K5NC6nuejYKHmM6KuKG6QOjYMJjQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-1.19.2.tgz",
+      "integrity": "sha512-FK8C26HaMz4XSIT3iiP6SYb5oNNBR2+OPc3Fq6yCBfx/Nzyw6pK69A9DszxKNZ7R4BACSZRYJqbhvqyxEBK2CA==",
       "dev": true
     },
     "@comunica/mediator-all": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-1.18.1.tgz",
-      "integrity": "sha512-G8J3O6WPQmGLrODD+qJ6yx43fgGgoSaXXwpw+PYaQAviQ1fHH0BWU4RHCKADqAYLYkHWjM4NpGOPAlWTMCjFKA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-1.19.2.tgz",
+      "integrity": "sha512-NgVXh9aRsFaurXh5BElLYYn1R+90q4itq+DcJbHKJsC87ysuLUazVKe1vNLohvJbdfst0Ga1WUH7Q9RpB75Uhw==",
       "dev": true
     },
     "@comunica/mediator-combine-pipeline": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-1.18.1.tgz",
-      "integrity": "sha512-ZLqgTXjKc2WX+udGZun07eMhUYZACOL04ME0u0J0RwudOahQX6wnC4qR32UpFN9pS/n3kMBBHCye4ZtJHDrzsQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-1.19.2.tgz",
+      "integrity": "sha512-j9YXmKJH350lBy2vkjYC2ouikkPXDllEdr0xUl3uVUcz56Gr0Jn/tUUl/kGteLHSb+wMzmBvpbbedBoVpfhLbQ==",
       "dev": true
     },
     "@comunica/mediator-combine-union": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.18.1.tgz",
-      "integrity": "sha512-w4S4WNwjh+8zjz154YaEL1p4VWYYD5yNhPTH/mIvk5IS2R6TLqTQ0qlk5JvOvDA5aL8IiOndG0rTPXxFS8dhxw==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.19.2.tgz",
+      "integrity": "sha512-UHC0yS8rVbSqyg8ndyKSxd8lLnQYiMzyYwbTQyMSSOJCc7WCYPXME1IMlNlsO7c0BC7hxXLZPkeIGLAYh5/CEg==",
       "dev": true
     },
     "@comunica/mediator-number": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.18.1.tgz",
-      "integrity": "sha512-nJNrMi01l9eLEttWlcIvabLoOEr31Dw19VoOClYvPC315e60DYuX4b5PTZNIuTTjv5x39DVRQ2qjFVMdFjn3sQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.19.2.tgz",
+      "integrity": "sha512-VMT2yM++DxQUhR7IJp1yS1rOXzIyXY3si4SQQMzAKIUGwgVWvW/SnB9Ds3JLXnNl4Ptb7Y+kRQZAffHZzBw41w==",
       "dev": true
     },
     "@comunica/mediator-race": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.18.1.tgz",
-      "integrity": "sha512-UN9yT62mHTbIvCxyMyMx63wbYVB2Z7tq0pzHrVOUTlx09QMHkyIr8wVkaAiTzXfm/PKTX9awNNpmXrAz9Sw8kA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.19.2.tgz",
+      "integrity": "sha512-F+PxeAWTrMEW0s48oaV5h3YrywoO3vPqCgSKyDfRx2YtjJX3SjJduGVNsKKCK4oWNG/NINOg3eUaTG8p4JMbWQ==",
       "dev": true
     },
     "@comunica/mediatortype-iterations": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-iterations/-/mediatortype-iterations-1.18.1.tgz",
-      "integrity": "sha512-FYqUBfu5UYc5dsZp9IxtZ/dp0w2XRoZM1i3nL9xmEM4kiQSM4q2ucTULj+VVBAkAJnDmMf9aajMCbB0+VQBjrA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-iterations/-/mediatortype-iterations-1.19.2.tgz",
+      "integrity": "sha512-FegoAy36aa3dceqSo747YmDOgUdkLVYb5QvW8I0+uBNkfUcYJAzvne36ERVIcIPrhNkkS5KFYR+P4Nw4mHcHkA==",
       "dev": true
     },
     "@comunica/runner": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-1.18.1.tgz",
-      "integrity": "sha512-rH+xDg3cMiD0dRLuiwUA131pY6unJjupglReBi6RDvUnQIR4yxD5HZlbx/K7gW/Y+ae1/MV1/gbVQY4DRkh8Rg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-1.19.2.tgz",
+      "integrity": "sha512-BfwVSI1M3/cPxC/006KyR1TDnmuxGY+lENZRAs3BWc1RaCmkcU/V9+yrxWmUHYfSZgVZ4sQovkC/BTwLiMUBaw==",
       "dev": true,
       "requires": {
-        "componentsjs": "^3.4.1"
+        "componentsjs": "^4.0.3"
       }
     },
     "@comunica/runner-cli": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-1.18.1.tgz",
-      "integrity": "sha512-C0T4esawRcr0RQvd9JUkC0gp/JsNOZtnIBhaILIH2gs/63XfwdYO/JvtyqyOVdppf3f0bP8rSVwGy7/O3xjuGQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-1.19.2.tgz",
+      "integrity": "sha512-glBNAUURfwmD1/xTwJNfw3vBoBp9Lzagqe/gcpzGhj+62xZ5KBfoE9fMu9gFfc10uXHHuvoXTfIISfxQbWd0SA==",
       "dev": true,
       "requires": {
-        "@comunica/runner": "^1.18.1"
+        "@comunica/runner": "^1.19.2"
       }
     },
     "@comunica/utils-datasource": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-datasource/-/utils-datasource-1.18.1.tgz",
-      "integrity": "sha512-MMwidHX8gNm/VRuonNS486RfA6UUWdRSCloEjP7++4we1yOBvjfdrcoB267rKxiKCoNcgSZlhxN6wfBGcg+S0Q==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-datasource/-/utils-datasource-1.19.2.tgz",
+      "integrity": "sha512-XZ/qg5cq/0N/ixqbV9dnYkGK/deELdHUSiWV6Mt6OuRqI1d2m0UEid5SFa1eaaHgjLFAbf01YH0TglVtiOKNfQ==",
       "dev": true,
       "requires": {
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.18.1",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.19.2",
         "asynciterator": "^3.0.3"
+      }
+    },
+    "@dabh/diagnostics": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+      "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+      "dev": true,
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "@emmetio/extract-abbreviation": {
@@ -2840,9 +2881,9 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
-      "integrity": "sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
+      "integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -2852,7 +2893,7 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -2888,12 +2929,6 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
           "dev": true
         }
       }
@@ -2964,9 +2999,9 @@
       }
     },
     "@open-wc/scoped-elements": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-1.3.2.tgz",
-      "integrity": "sha512-DoP3XA8r03tGx+IrlJwP/voLuDFkyS56kvwhmXIhpESo7M5jMt5e0zScNrawj7EMe4b5gDaJjorx2Jza8FLaLw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-1.3.3.tgz",
+      "integrity": "sha512-vFIQVYYjFw67odUE4JzZOpctnF7S/2DX+S+clrL3bQPql7HvEnV0wMFwOWUavQTuCJi0rfU8GTcNMiUybio+Yg==",
       "dev": true,
       "requires": {
         "@open-wc/dedupe-mixin": "^1.3.0",
@@ -3209,9 +3244,9 @@
       }
     },
     "@rollup/plugin-node-resolve": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.0.1.tgz",
-      "integrity": "sha512-ltlsj/4Bhwwhb+Nb5xCz/6vieuEj2/BAkkqVIKmZwC7pIdl8srmgmglE4S0jFlZa32K4qvdQ6NHdmpRKD/LwoQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.1.1.tgz",
+      "integrity": "sha512-zlBXR4eRS+2m79TsUZWhsd0slrHUYdRx4JF+aVQm+MI0wsKdlpC2vlDVjmlGvtZY1vsefOT9w3JxvmWSBei+Lg==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
@@ -3220,18 +3255,6 @@
         "deepmerge": "^4.2.2",
         "is-module": "^1.0.0",
         "resolve": "^1.19.0"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.19.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.1.0",
-            "path-parse": "^1.0.6"
-          }
-        }
       }
     },
     "@rollup/pluginutils": {
@@ -3254,9 +3277,9 @@
       }
     },
     "@sinonjs/commons": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
-      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
+      "integrity": "sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -3272,9 +3295,9 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.0.tgz",
-      "integrity": "sha512-hXpcfx3aq+ETVBwPlRFICld5EnrkexXuXDwqUNhDdr5L8VjvMeSRwyOa0qL7XFmR+jVWR4rUZtnxlG7RX72sBg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
+      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.6.0",
@@ -3308,9 +3331,9 @@
       }
     },
     "@types/chai": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.14.tgz",
-      "integrity": "sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==",
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.15.tgz",
+      "integrity": "sha512-rYff6FI+ZTKAPkJUoyz7Udq3GaoDZnxYDEvdEdFZASiA7PoErltHezDishqQiSDWrGxvxmplH304jyzQmjp0AQ==",
       "dev": true
     },
     "@types/chai-dom": {
@@ -3371,13 +3394,13 @@
       "dev": true
     },
     "@types/express": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.10.tgz",
-      "integrity": "sha512-GRwKdE+iV6mA8glCvQ7W5iaoIhd6u1HDsNTF76UPRi7T89SLjOfeCLShVmQSgpXzcpf3zgcz2SbMiCcjnYRRxQ==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.11.tgz",
+      "integrity": "sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
+        "@types/express-serve-static-core": "^4.17.18",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
@@ -3433,9 +3456,9 @@
       "dev": true
     },
     "@types/koa": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.11.6.tgz",
-      "integrity": "sha512-BhyrMj06eQkk04C97fovEDQMpLpd2IxCB4ecitaXwOKGq78Wi2tooaDOWOFGajPk8IkQOAtMppApgSVkYe1F/A==",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.11.8.tgz",
+      "integrity": "sha512-8LJHhlEjxvEb9MR06zencOxZyxpTHG2u6pcvJbSBN9DRBc+GYQ9hFI8sSH7dvYoITKeAGWo2eVPKx1Z/zX/yKw==",
       "dev": true,
       "requires": {
         "@types/accepts": "*",
@@ -3457,12 +3480,6 @@
         "@types/koa": "*"
       }
     },
-    "@types/lodash": {
-      "version": "4.14.167",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.167.tgz",
-      "integrity": "sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw==",
-      "dev": true
-    },
     "@types/lru-cache": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
@@ -3470,9 +3487,9 @@
       "dev": true
     },
     "@types/mime": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
-      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
     },
     "@types/minimist": {
@@ -3498,9 +3515,9 @@
       }
     },
     "@types/node": {
-      "version": "14.14.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
-      "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==",
+      "version": "14.14.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.27.tgz",
+      "integrity": "sha512-Ecfmo4YDQPwuqTCl1yBxLV5ihKfRlkBmzUEDcfIRvDxOTGQEeikr317Ln7Gcv0tjA8dVgKI3rniqW2G1OyKDng==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -3543,9 +3560,9 @@
       "dev": true
     },
     "@types/rdf-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-4.0.0.tgz",
-      "integrity": "sha512-2uaR7ks0380MqzUWGOPOOk9yZIr/6MOaCcaj3ntKgd2PqNocgi8j5kSHIJTDe+5ABtTHqKMSE0v0UqrsT8ibgQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-4.0.1.tgz",
+      "integrity": "sha512-S+28+3RoFI+3arls7dS813gYnhb2HiyLX+gs00rgIvCzHU93DaYajhx4tyT+XEO8SjtzZw90OF4OVdYXBwbvkQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -3560,13 +3577,19 @@
         "@types/node": "*"
       }
     },
+    "@types/semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==",
+      "dev": true
+    },
     "@types/serve-static": {
-      "version": "1.13.8",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.8.tgz",
-      "integrity": "sha512-MoJhSQreaVoL+/hurAZzIm8wafFR6ajiTM1m4A0kv6AGeVBl4r4pOV8bGFrjjq1sGxDTnCoF8i22o0/aE5XCyA==",
+      "version": "1.13.9",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.9.tgz",
+      "integrity": "sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==",
       "dev": true,
       "requires": {
-        "@types/mime": "*",
+        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
@@ -3660,9 +3683,9 @@
       }
     },
     "@web/browser-logs": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@web/browser-logs/-/browser-logs-0.2.0.tgz",
-      "integrity": "sha512-BExeD4Rlak10X+R38dDfc3waYu2dHEvMNqIottCwFXXoMvLeQs0+fYB2fqpcQwMoAIhhKRo9NENtuQQLaR1y0A==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@web/browser-logs/-/browser-logs-0.2.1.tgz",
+      "integrity": "sha512-nSfRl/+7XQOtXBBJ9FMdXAb1bzytud1LeJAJmBX4bsfMDDcfrr4vNhiX4OnQ5tBYsXoiQse8ZvwngFM2O6PD3A==",
       "dev": true,
       "requires": {
         "errorstacks": "^2.2.0"
@@ -3675,30 +3698,19 @@
       "dev": true,
       "requires": {
         "semver": "^7.3.4"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@web/dev-server": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@web/dev-server/-/dev-server-0.1.4.tgz",
-      "integrity": "sha512-aYqrUFd6s32QJ4vPJlKGoD66U/I4erMSIzEInvN4IcUqUKQyF7Ol11J+QU0t2lkBAfoH4/yD2PzZXRC51P04dA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@web/dev-server/-/dev-server-0.1.7.tgz",
+      "integrity": "sha512-JFUGvSQMCoNJwkdLuzbxAv/Fj7hcWRW/DFUwBFh1Qz61wIOMnoj6iJ5rGZnTiC/9aK8SLIBXaDWA5Kd2X3ntcw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.11",
         "@rollup/plugin-node-resolve": "^11.0.1",
         "@types/command-line-args": "^5.0.0",
         "@web/config-loader": "^0.1.3",
-        "@web/dev-server-core": "^0.3.2",
+        "@web/dev-server-core": "^0.3.6",
         "@web/dev-server-rollup": "^0.3.2",
         "camelcase": "^6.2.0",
         "chalk": "^4.1.0",
@@ -3735,18 +3747,33 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         }
       }
     },
     "@web/dev-server-core": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@web/dev-server-core/-/dev-server-core-0.3.3.tgz",
-      "integrity": "sha512-zj70hj6FBIFAGZfyqrOlDY1bYtqTea5ioTcgGx55tIeHiUmblDCcpbBUIqj4pcw/GjpQPBBFw5oX1WyuiHQNhA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@web/dev-server-core/-/dev-server-core-0.3.6.tgz",
+      "integrity": "sha512-AAVdxMVMJd7st3NsLDlRWBQRPUL0pYZxTqsdnoYwhcf5hDmxAWwcR2wcQRuM3g2pa+Vh+9qjpJeinU58ZBfzqw==",
       "dev": true,
       "requires": {
         "@types/koa": "^2.11.6",
         "@types/ws": "^7.4.0",
-        "@web/parse5-utils": "^1.0.0",
+        "@web/parse5-utils": "^1.2.0",
         "chokidar": "^3.4.3",
         "clone": "^2.1.2",
         "es-module-lexer": "^0.3.26",
@@ -3795,13 +3822,28 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         }
       }
     },
     "@web/parse5-utils": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@web/parse5-utils/-/parse5-utils-1.1.2.tgz",
-      "integrity": "sha512-/JQHbK53BmYiFK2igr2B+Psl2Ivp2ju75Nx1InZweTbxLQNGG9yUBaudER85aqebIH6smkPkKwVtpdBXBiwy1A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@web/parse5-utils/-/parse5-utils-1.2.0.tgz",
+      "integrity": "sha512-/v1L5rBFh76BuXHPzoozS+viBzbErEtOBVEq8SSr9LpUzRlPSohzgMvJN3EgYW5FrbgXJkigWd19V67w7B/aJw==",
       "dev": true,
       "requires": {
         "@types/parse5": "^5.0.3",
@@ -3817,21 +3859,22 @@
       }
     },
     "@web/test-runner": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.12.2.tgz",
-      "integrity": "sha512-7wQ2b3OE4xuAhHOaFbs+9d06bWNKvm9hWjJdHbLczsAkq2+TPbZDynw2b1D2fkTLcOWNbGOyQa742ThWIbXYRw==",
+      "version": "0.12.15",
+      "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.12.15.tgz",
+      "integrity": "sha512-v9VehhdoELkPs9u0XQrXu8BKzIRlx/U8F8YLsz8tV/bi8Mb7Riqvku0OdFu1P4vjf4NnElpx9J97/WBXURBwLg==",
       "dev": true,
       "requires": {
         "@web/browser-logs": "^0.2.0",
         "@web/config-loader": "^0.1.3",
-        "@web/dev-server": "^0.1.4",
-        "@web/test-runner-chrome": "^0.9.0",
-        "@web/test-runner-commands": "^0.4.0",
-        "@web/test-runner-core": "^0.10.2",
-        "@web/test-runner-mocha": "^0.7.0",
+        "@web/dev-server": "^0.1.7",
+        "@web/test-runner-chrome": "^0.9.4",
+        "@web/test-runner-commands": "^0.4.1",
+        "@web/test-runner-core": "^0.10.11",
+        "@web/test-runner-mocha": "^0.7.2",
         "camelcase": "^6.2.0",
         "chalk": "^4.1.0",
         "command-line-args": "^5.1.1",
+        "command-line-usage": "^6.1.1",
         "convert-source-map": "^1.7.0",
         "deepmerge": "^4.2.2",
         "diff": "^5.0.0",
@@ -3865,6 +3908,21 @@
             "supports-color": "^7.1.0"
           }
         },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
         "diff": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -3880,38 +3938,40 @@
       }
     },
     "@web/test-runner-chrome": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-chrome/-/test-runner-chrome-0.9.0.tgz",
-      "integrity": "sha512-Ez0X0h527R1HqW44qlCDid6/ctLs1mg14v1jmXkJ+rhaM67ZbAGF4Lp/ZUeLzVysm3NtNP9Glrj+w5BD3PDYSQ==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-chrome/-/test-runner-chrome-0.9.4.tgz",
+      "integrity": "sha512-Ymfp0HqQvELFITdwhdicuzndLY5loePpbDj6teXKKNTILph0ExWl3R3NMPG7pD40pB84GGd9i8wkz9yvyN30Zg==",
       "dev": true,
       "requires": {
-        "@web/test-runner-core": "^0.10.0",
-        "@web/test-runner-coverage-v8": "^0.4.0",
+        "@web/test-runner-core": "^0.10.8",
+        "@web/test-runner-coverage-v8": "^0.4.5",
         "chrome-launcher": "^0.13.4",
         "puppeteer-core": "^5.5.0"
       }
     },
     "@web/test-runner-commands": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-commands/-/test-runner-commands-0.4.0.tgz",
-      "integrity": "sha512-FsmF4Ya2mK8nlrodSjLMK1iKsSz61l4LeHSNRBjZtlzfjfwoGb38Pq+WehtboKgan+if/daHBjW85QFO1j3O+Q==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-commands/-/test-runner-commands-0.4.1.tgz",
+      "integrity": "sha512-y1U9+jucQ1ZB9YRgMFIjXTUSu/in54yt4Lf4GcY9fHoSyGVWDub085ARWipmagsD9SRN1QnIYTkMk+jRa/EiLQ==",
       "dev": true,
       "requires": {
-        "@web/test-runner-core": "^0.10.0"
+        "@web/test-runner-core": "^0.10.8"
       }
     },
     "@web/test-runner-core": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-core/-/test-runner-core-0.10.2.tgz",
-      "integrity": "sha512-BLEdRsekHJW02Cq/mezTMFcDwtsTvwoJ0Oo+0q/VxRzvpH2ae5VhySPfAuCA1xXCfttPBb/RYLH0BVq8bp57LA==",
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-core/-/test-runner-core-0.10.11.tgz",
+      "integrity": "sha512-0V2eF58vtQgo4TR6jPEw53CRaT3lD+PlgjjDcnZb8rWp/1ZIt3QAnzNCeSsV4DsuABzE3eyUkIBNILLky541rw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.11",
-        "@web/browser-logs": "^0.2.0",
-        "@web/dev-server-core": "^0.3.3",
+        "@web/browser-logs": "^0.2.1",
+        "@web/dev-server-core": "^0.3.6",
         "chalk": "^4.1.0",
+        "chokidar": "^3.4.3",
         "cli-cursor": "^3.1.0",
         "co-body": "^6.1.0",
+        "convert-source-map": "^1.7.0",
         "debounce": "^1.2.0",
         "dependency-graph": "^0.10.0",
         "globby": "^11.0.1",
@@ -3920,7 +3980,9 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-reports": "^3.0.2",
         "log-update": "^4.0.0",
+        "open": "^7.3.0",
         "picomatch": "^2.2.2",
+        "source-map": "^0.7.3",
         "uuid": "^8.3.2"
       },
       "dependencies": {
@@ -3942,28 +4004,50 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
         }
       }
     },
     "@web/test-runner-coverage-v8": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-coverage-v8/-/test-runner-coverage-v8-0.4.0.tgz",
-      "integrity": "sha512-6dPZBLe69y6Lat3CACo1F0CMZae2s8O/lNLgIJT/LMT8bHtQ/9kZAkLraCwJ+NMHXI6G5Y5t0nSPulSvzTqs7g==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-coverage-v8/-/test-runner-coverage-v8-0.4.6.tgz",
+      "integrity": "sha512-Mt8hzLUZfMBrpFlo8PYIkM5H77XmnuiF2VrRXvLRRMBz6sZ+WqZmPT5fOznvTEoqOXh92XG9SsW+G0uV6HjdPQ==",
       "dev": true,
       "requires": {
-        "@web/test-runner-core": "^0.10.0",
+        "@web/test-runner-core": "^0.10.9",
         "istanbul-lib-coverage": "^3.0.0",
+        "picomatch": "^2.2.2",
         "v8-to-istanbul": "^7.1.0"
       }
     },
     "@web/test-runner-mocha": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-mocha/-/test-runner-mocha-0.7.0.tgz",
-      "integrity": "sha512-GW/cCXjChBcIaaNnSIH/Yy04jd+mdZPNE2UcWVkl0h3Z/iJu+a10S1jkaoY2SfGFhH/20AbrM+8EGMFbSUpaGA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-mocha/-/test-runner-mocha-0.7.2.tgz",
+      "integrity": "sha512-UsaLvJ0k5Kb53WegF0J0pmKxCLdo6Nxl7GHYykO7m99Irz+jIGXV7VJP9/b8t+HH3fHyqB2Nmd5q9oxXwIJyNw==",
       "dev": true,
       "requires": {
         "@types/mocha": "^8.2.0",
-        "@web/test-runner-core": "^0.10.0"
+        "@web/test-runner-core": "^0.10.8"
       },
       "dependencies": {
         "@types/mocha": {
@@ -3975,13 +4059,13 @@
       }
     },
     "@web/test-runner-playwright": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-playwright/-/test-runner-playwright-0.8.0.tgz",
-      "integrity": "sha512-VoRfBxioOJuUFRROcwKkXL75iRtf4Qc9zVSGUvVlCZoLstG5EuqYyuvIdnGCkcf/sqCXsAh1WbQ+wfRXd7h6Cw==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-playwright/-/test-runner-playwright-0.8.4.tgz",
+      "integrity": "sha512-9RCez2kB0AocMasrUsmx/yW7FGSjBI9aEtjYzkFvRJF21IsEyjCrmmGPdBIa75a/gU2ydPaw0EQW4TDF5L4yRw==",
       "dev": true,
       "requires": {
-        "@web/test-runner-core": "^0.10.0",
-        "@web/test-runner-coverage-v8": "^0.4.0",
+        "@web/test-runner-core": "^0.10.8",
+        "@web/test-runner-coverage-v8": "^0.4.5",
         "playwright": "^1.7.1"
       }
     },
@@ -4093,9 +4177,9 @@
       "dev": true
     },
     "amf-client-js": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/amf-client-js/-/amf-client-js-4.6.0.tgz",
-      "integrity": "sha512-hep/WF+qDsVVbCsdNOYjtlWGB60bLhEkfLpZXYjJDB6sYfI2E9rYouUlir3qtGDjuczVCI5HaDoLB5Vjpz6GRA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/amf-client-js/-/amf-client-js-4.7.0.tgz",
+      "integrity": "sha512-rl3TFIoIab7iulTzw3a3WCaf18TIavWFQxlevzipoO/c8B1B91K9TUzGVqhYWuKhDcsMxYe1mACX5J7vI52nUQ==",
       "dev": true,
       "requires": {
         "ajv": "6.5.2",
@@ -4250,21 +4334,6 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
-    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -4284,13 +4353,10 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+      "dev": true
     },
     "asynciterator": {
       "version": "3.0.3",
@@ -4299,19 +4365,13 @@
       "dev": true
     },
     "asyncjoin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/asyncjoin/-/asyncjoin-1.0.1.tgz",
-      "integrity": "sha512-FjqqH7H9YUbE51U6xX4hQfzIAbyEKSZLdhdQNvl0kQ2vZvgiYgW1o1Vl4LJIU+3fu7ld3Tdcq72G5/h6OALsBw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/asyncjoin/-/asyncjoin-1.0.2.tgz",
+      "integrity": "sha512-q5p5mqVXiL7KD6ihJad+6vaLHEQ73u5K5UyKerVGRA3Ec4AuhaoxpRU/qtQiV1eK2gMiO9T4OMSIG90hY1Fl+g==",
       "dev": true,
       "requires": {
         "asynciterator": "^3.0.0"
       }
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -4325,22 +4385,10 @@
       "integrity": "sha512-y/+ek8IjxVpTbj/phC87jK5YRhlP5Uu7FlQdCmYuut1DTjNruyrGqUWi5bcX1VKsQX1B0FX16A1hqHomKpHv3A==",
       "dev": true
     },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
-    },
-    "aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "dev": true
-    },
     "axe-core": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.1.tgz",
-      "integrity": "sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.2.tgz",
+      "integrity": "sha512-V+Nq70NxKhYt89ArVcaNL9FDryB3vQOd+BFXZIfO3RP6rwtj+2yqqqdHEkacutglPaZLkJeuXKCjCJDMGPtPqg==",
       "dev": true
     },
     "axobject-query": {
@@ -4367,15 +4415,6 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -4383,9 +4422,9 @@
       "dev": true
     },
     "bl": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
       "requires": {
         "buffer": "^5.5.0",
@@ -4510,16 +4549,10 @@
       "integrity": "sha512-mAjKJPIyP0xqqv6IAkvso07StOmz6cmGtNDg3pXCSzXVZOqka7StIkAhJl/zHOi4M2CgpYfD6aeRWbnrmtvBEA==",
       "dev": true
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
-    },
     "chai": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.0.tgz",
+      "integrity": "sha512-/BFd2J30EcOwmdOgXvVsmM48l0Br0nmZPlO0uOW4XKh6kpsUumRXBgPV+IlaqFaqr9cYbeoZAM1Npx0i4A+aiA==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
@@ -4569,13 +4602,14 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.0.tgz",
-      "integrity": "sha512-JgQM9JS92ZbFR4P90EvmzNpSGhpPBGBSj10PILeDyYFwp4h2/D9OM03wsJ4zW1fEp4ka2DGrnUeD7FuvQ2aZ2Q==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -4642,6 +4676,21 @@
           "requires": {
             "color-convert": "^2.0.1"
           }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "slice-ansi": {
           "version": "3.0.0",
@@ -4720,33 +4769,60 @@
       }
     },
     "codemirror": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.59.1.tgz",
-      "integrity": "sha512-d0SSW/PCCD4LoSCBPdnP0BzmZB1v3emomCUtVlIWgZHJ06yVeBOvBtOH7vYz707pfAvEeWbO9aP6akh8vl1V3w==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.59.2.tgz",
+      "integrity": "sha512-/D5PcsKyzthtSy2NNKCyJi3b+htRkoKv3idswR/tR6UAvMNKA7SrmyZy6fOONJxSRs1JlUWEDAbxqfdArbK8iA==",
       "dev": true
     },
-    "color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
       "dev": true,
       "requires": {
-        "color-name": "~1.1.4"
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+    "color-string": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
+      "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "dev": true,
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
       }
     },
     "command-line-args": {
@@ -4798,21 +4874,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
@@ -4877,44 +4938,24 @@
       "dev": true
     },
     "componentsjs": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-3.6.1.tgz",
-      "integrity": "sha512-Qnnqo9Lx7yBhK8ttkwjFYAkY300P9gvr4S9q50tWU/O01dzSdBxX/rvvx9HBa3PxMOkV1UaBkmztU7Rmq92uZQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-4.0.6.tgz",
+      "integrity": "sha512-MPvKSLVo4SX3PafGMqKPzV+i8JdivYXuaJb2CsEF86TUgniXX3i661D0MDBwMWnd0LXWbI1sNq0kKJBKrL/wBw==",
       "dev": true,
       "requires": {
-        "@types/lodash": "^4.14.56",
         "@types/minimist": "^1.2.0",
-        "@types/n3": "0.0.3",
-        "@types/node": "8.10.21",
-        "global-modules": "^1.0.0",
-        "jsonld": "^0.4.11",
-        "lodash": "^4.17.4",
+        "@types/node": "^14.14.7",
+        "@types/rdf-js": "*",
+        "@types/semver": "^7.3.4",
+        "jsonld-context-parser": "^2.1.1",
         "minimist": "^1.2.0",
-        "n3": "^0.9.1",
-        "requireg": "^0.1.7"
-      },
-      "dependencies": {
-        "@types/n3": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/@types/n3/-/n3-0.0.3.tgz",
-          "integrity": "sha512-oqywrU7RdLKO0Ndnrue8smXR+oLW4EgFGrd/ewaYbkZjgr/eRpwpjsJk9D5Z8AF+cZKYbiQtR5BR6LNlLl0HPQ==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "@types/node": {
-          "version": "8.10.21",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.21.tgz",
-          "integrity": "sha512-87XkD9qDXm8fIax+5y7drx84cXsu34ZZqfB7Cial3Q/2lxSoJ/+DRaWckkCbxP41wFSIrrb939VhzaNxj4eY1w==",
-          "dev": true
-        },
-        "n3": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/n3/-/n3-0.9.1.tgz",
-          "integrity": "sha1-QwtUfVjcc4FAjEV4TdgFgXGQOTI=",
-          "dev": true
-        }
+        "rdf-data-factory": "^1.0.4",
+        "rdf-object": "^1.8.0",
+        "rdf-parse": "^1.7.0",
+        "rdf-quad": "^1.5.0",
+        "rdf-terms": "^1.6.2",
+        "semver": "^7.3.2",
+        "winston": "^3.3.3"
       }
     },
     "concat-map": {
@@ -5033,15 +5074,15 @@
       }
     },
     "core-js": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.2.tgz",
-      "integrity": "sha512-FfApuSRgrR6G5s58casCBd9M2k+4ikuu4wbW6pJyYU7bd9zvFc9qf7vr5xmrZOhT9nn+8uwlH1oRR9jTnFoA3A==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
+      "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==",
       "dev": true
     },
     "core-js-pure": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.2.tgz",
-      "integrity": "sha512-v6zfIQqL/pzTVAbZvYUozsxNfxcFb6Ks3ZfEbuneJl3FW9Jb8F6vLWB6f+qTmAu72msUdyb84V8d/yBFf7FNnw==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.3.tgz",
+      "integrity": "sha512-V5qQZVAr9K0xu7jXg1M7qTEwuxUgqr7dUOezGaNa7i+Xn9oXAU/d1fzqD9ObuwpVQOaorO5s70ckyi1woP9lVA==",
       "dev": true
     },
     "core-util-is": {
@@ -5081,17 +5122,6 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
-      },
-      "dependencies": {
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
       }
     },
     "crypt": {
@@ -5120,15 +5150,6 @@
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
       "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
       "dev": true
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
     },
     "debounce": {
       "version": "1.2.0",
@@ -5239,12 +5260,6 @@
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
-    },
     "delegate": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
@@ -5324,17 +5339,6 @@
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0",
         "entities": "^2.0.0"
-      },
-      "dependencies": {
-        "domhandler": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-          "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^2.1.0"
-          }
-        }
       }
     },
     "dom5": {
@@ -5363,12 +5367,12 @@
       "dev": true
     },
     "domhandler": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
-      "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
+      "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
       "dev": true,
       "requires": {
-        "domelementtype": "^2.0.1"
+        "domelementtype": "^2.1.0"
       }
     },
     "dompurify": {
@@ -5385,17 +5389,6 @@
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0"
-      },
-      "dependencies": {
-        "domhandler": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
-          "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^2.1.0"
-          }
-        }
       }
     },
     "dot-prop": {
@@ -5413,16 +5406,6 @@
       "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
       "dev": true
     },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -5433,6 +5416,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "dev": true
     },
     "encodeurl": {
@@ -5481,9 +5470,9 @@
       }
     },
     "entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "dev": true
     },
     "errno": {
@@ -5502,6 +5491,14 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "dev": true
+        }
       }
     },
     "errorstacks": {
@@ -5511,23 +5508,25 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.18.0-next.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+      "version": "1.18.0-next.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
+      "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
         "is-callable": "^1.2.2",
-        "is-negative-zero": "^2.0.0",
+        "is-negative-zero": "^2.0.1",
         "is-regex": "^1.1.1",
-        "object-inspect": "^1.8.0",
+        "object-inspect": "^1.9.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.1",
-        "string.prototype.trimend": "^1.0.1",
-        "string.prototype.trimstart": "^1.0.1"
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.3",
+        "string.prototype.trimstart": "^1.0.3"
       }
     },
     "es-module-lexer": {
@@ -5558,12 +5557,6 @@
         "through": "~2.3.4"
       }
     },
-    "es6-promise": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-      "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw=",
-      "dev": true
-    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -5577,13 +5570,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.17.0.tgz",
-      "integrity": "sha512-zJk08MiBgwuGoxes5sSQhOtibZ75pz0J35XTRlZOk9xMffhpA9BTbQZxoXZzOl5zMbleShbGwtw+1kGferfFwQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.19.0.tgz",
+      "integrity": "sha512-CGlMgJY56JZ9ZSYhJuhow61lMPPjUzWmChFya71Z/jilVos7mR/jPgaEfVGgMBY5DshbKdG8Ezb8FDCHcoMEMg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@eslint/eslintrc": "^0.2.2",
+        "@eslint/eslintrc": "^0.3.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -5607,7 +5600,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -5652,6 +5645,21 @@
             "supports-color": "^7.1.0"
           }
         },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -5681,12 +5689,6 @@
           "requires": {
             "ansi-regex": "^5.0.0"
           }
-        },
-        "strip-json-comments": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-          "dev": true
         }
       }
     },
@@ -5702,9 +5704,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.1.0.tgz",
-      "integrity": "sha512-9sm5/PxaFG7qNJvJzTROMM1Bk1ozXVTKI0buKOyb0Bsr1hrwi0H/TzxF/COtf1uxikIK8SwhX7K6zg78jAzbeA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
+      "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -5715,18 +5717,6 @@
       "requires": {
         "debug": "^2.6.9",
         "resolve": "^1.13.1"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.19.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.1.0",
-            "path-parse": "^1.0.6"
-          }
-        }
       }
     },
     "eslint-module-utils": {
@@ -5746,6 +5736,29 @@
       "dev": true,
       "requires": {
         "htmlparser2": "^5.0.1"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+          "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1"
+          }
+        },
+        "htmlparser2": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz",
+          "integrity": "sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.3.0",
+            "domutils": "^2.4.2",
+            "entities": "^2.0.0"
+          }
+        }
       }
     },
     "eslint-plugin-import": {
@@ -5792,12 +5805,6 @@
           "version": "2.8.8",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
           "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "locate-path": {
@@ -5882,16 +5889,6 @@
             "read-pkg": "^2.0.0"
           }
         },
-        "resolve": {
-          "version": "1.19.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.1.0",
-            "path-parse": "^1.0.6"
-          }
-        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -5931,9 +5928,9 @@
       },
       "dependencies": {
         "emoji-regex": {
-          "version": "9.2.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.0.tgz",
-          "integrity": "sha512-DNc3KFPK18bPdElMJnf/Pkv5TXhxFU3YFDEuGLDRtPmV4rkmCjBkCSEp22u6rBHdSN9Vlp/GK7k98prmE1Jgug==",
+          "version": "9.2.1",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.1.tgz",
+          "integrity": "sha512-117l1H6U4X3Krn+MrzYrL57d5H7siRHWraBs7s+LjRuFK7Fe7hJqnJ0skWlinqsycVLU5YAo6L8CsEYQ0V5prg==",
           "dev": true
         },
         "parse5": {
@@ -6049,9 +6046,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
@@ -6140,21 +6137,6 @@
         }
       }
     },
-    "expand-tilde": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-      "dev": true,
-      "requires": {
-        "homedir-polyfill": "^1.0.1"
-      }
-    },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
-    },
     "extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -6193,12 +6175,6 @@
         }
       }
     },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
-    },
     "falafel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
@@ -6216,6 +6192,12 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
           "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ=",
           "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
         }
       }
     },
@@ -6226,9 +6208,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
-      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -6251,10 +6233,16 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
+      "dev": true
+    },
     "fastq": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz",
-      "integrity": "sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.1.tgz",
+      "integrity": "sha512-AWuv6Ery3pM+dY7LYS8YIaCiQvUaos9OB1RyNgaOWnaX+Tik7Onvcsf8x8c+YtDeT0maYLniBip2hox5KtEXXA==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -6268,6 +6256,12 @@
       "requires": {
         "pend": "~1.2.0"
       }
+    },
+    "fecha": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
+      "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg==",
+      "dev": true
     },
     "fetch-cookie": {
       "version": "0.10.1",
@@ -6379,15 +6373,21 @@
       }
     },
     "flatted": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.0.tgz",
-      "integrity": "sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+      "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+      "dev": true
+    },
+    "fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==",
       "dev": true
     },
     "foreach": {
@@ -6395,23 +6395,6 @@
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
     },
     "fresh": {
       "version": "0.5.2",
@@ -6442,6 +6425,13 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -6467,9 +6457,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
-      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
@@ -6495,23 +6485,14 @@
       "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
       "dev": true
     },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "git-raw-commits": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.9.tgz",
-      "integrity": "sha512-hSpNpxprVno7IOd4PZ93RQ+gNdzPAIrW0x8av6JQDJGV4k1mR9fE01dl8sEqi2P7aKmmwiGUn1BCPuf16Ae0Qw==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.10.tgz",
+      "integrity": "sha512-sHhX5lsbG9SOO6yXdlwgEMQ/ljIn7qMpAbJZCGfXX2fq5T8M5SrDnpYk9/4HswTildcIqatsWa91vty6VhWSaQ==",
       "dev": true,
       "requires": {
         "dargs": "^7.0.0",
-        "lodash.template": "^4.0.2",
+        "lodash": "^4.17.15",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
         "through2": "^4.0.0"
@@ -6568,30 +6549,6 @@
         "ini": "^1.3.4"
       }
     },
-    "global-modules": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-      "dev": true,
-      "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
-      }
-    },
-    "global-prefix": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-      "dev": true,
-      "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
-      }
-    },
     "globals": {
       "version": "12.4.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -6641,15 +6598,15 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
     },
     "graphql": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.4.0.tgz",
-      "integrity": "sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==",
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
+      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==",
       "dev": true
     },
     "graphql-ld": {
@@ -6684,42 +6641,6 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
-    },
-    "har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-          "dev": true
-        }
-      }
     },
     "hard-rejection": {
       "version": "2.1.0",
@@ -6813,19 +6734,10 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
-    "homedir-polyfill": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
-      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
-      "dev": true,
-      "requires": {
-        "parse-passwd": "^1.0.0"
-      }
-    },
     "hosted-git-info": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-      "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
+      "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -6838,14 +6750,14 @@
       "dev": true
     },
     "htmlparser2": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz",
-      "integrity": "sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.0.0.tgz",
+      "integrity": "sha512-numTQtDZMoh78zJpaNdJ9MXb2cv5G3jwUoe3dMQODubZvLoGvTE/Ofp6sHvH8OGKcN/8A47pGLi/k58xHP/Tfw==",
       "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^3.3.0",
-        "domutils": "^2.4.2",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.4.4",
         "entities": "^2.0.0"
       }
     },
@@ -6913,17 +6825,6 @@
       "integrity": "sha512-nARK1wSKoBBrtcoESlHBx36c1Ln/gnbNQi1eB6MeTUefJIT3NvUOsV15bClga0k38f0q/kN5xxrGSDS3EFnm9w==",
       "dev": true
     },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
-    },
     "https-proxy-agent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
@@ -6958,9 +6859,9 @@
       "dev": true
     },
     "husky": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.7.tgz",
-      "integrity": "sha512-0fQlcCDq/xypoyYSJvEuzbDPHFf8ZF9IXKJxlrnvxABTSzK1VPT2RKYQKrcgJ+YD39swgoB6sbzywUqFxUiqjw==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
+      "integrity": "sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
@@ -6993,6 +6894,21 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "find-up": {
           "version": "5.0.0",
@@ -7175,9 +7091,9 @@
       }
     },
     "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "dev": true
     },
     "is-binary-path": {
@@ -7196,9 +7112,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
       "dev": true
     },
     "is-core-module": {
@@ -7380,11 +7296,12 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.2",
         "has-symbols": "^1.0.1"
       }
     },
@@ -7424,22 +7341,10 @@
         "text-extensions": "^1.0.0"
       }
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
-    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
-    },
-    "is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
     "is-wsl": {
@@ -7452,9 +7357,9 @@
       }
     },
     "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isbinaryfile": {
@@ -7467,12 +7372,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "istanbul-lib-coverage": {
@@ -7538,22 +7437,10 @@
         }
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
-    },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
@@ -7575,12 +7462,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "dev": true
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json5": {
@@ -7613,18 +7494,6 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
-    "jsonld": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-0.4.12.tgz",
-      "integrity": "sha1-oC8gXVNBQU3xtthBTxuWenEgc+g=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "^2.0.0",
-        "pkginfo": "~0.4.0",
-        "request": "^2.61.0",
-        "xmldom": "0.1.19"
-      }
-    },
     "jsonld-context-parser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.1.1.tgz",
@@ -7640,9 +7509,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.39",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.39.tgz",
-          "integrity": "sha512-wct+WgRTTkBm2R3vbrFOqyZM5w0g+D8KnhstG9463CJBVC3UVZHMToge7iMBR1vDl/I+NWFHUeK9X+JcF0rWKw==",
+          "version": "13.13.41",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.41.tgz",
+          "integrity": "sha512-qLT9IvHiXJfdrje9VmsLzun7cQ65obsBTmtU3EOnCSLFOoSHx1hpiRHoBnpdbyFqnzqdUUIv81JcEJQCB8un9g==",
           "dev": true
         }
       }
@@ -7688,22 +7557,10 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
     "jsrsasign": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.1.4.tgz",
-      "integrity": "sha512-j+bG6EaQ/SBvQvnI8M2x3Wawz8jx3fBViPClAw84QpsnLSjtr5fobp5W2TAljpAhboxWvbkZmd/KDBm+hckqJQ==",
+      "version": "10.1.9",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.1.9.tgz",
+      "integrity": "sha512-fFUnXkFudI2WQrSsNI+8Ljsos2cDEQ59eATglUn/WpV2u8L69SWeVEZIZ2S93TOZASjgFuwfCUvup/VBYk65fQ==",
       "dev": true
     },
     "jstransform": {
@@ -7881,6 +7738,12 @@
         }
       }
     },
+    "kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "dev": true
+    },
     "level": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/level/-/level-6.0.1.tgz",
@@ -8027,9 +7890,9 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "10.5.3",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.5.3.tgz",
-      "integrity": "sha512-TanwFfuqUBLufxCc3RUtFEkFraSPNR3WzWcGF39R3f2J7S9+iF9W0KTVLfSy09lYGmZS5NDCxjNvhGMSJyFCWg==",
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.5.4.tgz",
+      "integrity": "sha512-EechC3DdFic/TdOPgj/RB3FicqE6932LTHCUm0Y2fsD9KGlLB+RwJl2q1IYBIvEsKzDOgn0D4gll+YxG5RsrKg==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -8068,6 +7931,21 @@
             "supports-color": "^7.1.0"
           }
         },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
         "commander": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -8101,9 +7979,9 @@
       }
     },
     "listr2": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.2.3.tgz",
-      "integrity": "sha512-vUb80S2dSUi8YxXahO8/I/s29GqnOL8ozgHVLjfWQXa03BNEeS1TpBLjh2ruaqq5ufx46BRGvfymdBSuoXET5w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.3.1.tgz",
+      "integrity": "sha512-8Zoxe7s/8nNr4bJ8bdAduHD8uJce+exmMmUWTXlq0WuUdffnH3muisHPHPFtW2vvOfohIsq7FGCaguUxN/h3Iw==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -8113,7 +7991,8 @@
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
         "rxjs": "^6.6.3",
-        "through": "^2.3.8"
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8133,6 +8012,41 @@
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
           }
         }
       }
@@ -8188,12 +8102,6 @@
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
-    "lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-      "dev": true
-    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -8217,25 +8125,6 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
-    },
-    "lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "dev": true,
-      "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "lodash.templatesettings": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "dev": true,
-      "requires": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
     },
     "lodash.uniqwith": {
       "version": "4.5.0",
@@ -8304,6 +8193,27 @@
         "cli-cursor": "^3.1.0",
         "slice-ansi": "^4.0.0",
         "wrap-ansi": "^6.2.0"
+      }
+    },
+    "logform": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+      "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
       }
     },
     "loud-rejection": {
@@ -8454,6 +8364,29 @@
         "htmlparser2": "^5.0.0",
         "rdf-data-factory": "^1.0.2",
         "relative-to-absolute-iri": "^1.0.2"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+          "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1"
+          }
+        },
+        "htmlparser2": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz",
+          "integrity": "sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.3.0",
+            "domutils": "^2.4.2",
+            "entities": "^2.0.0"
+          }
+        }
       }
     },
     "micromatch": {
@@ -8467,9 +8400,9 @@
       }
     },
     "mime": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
-      "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.0.tgz",
+      "integrity": "sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag==",
       "dev": true
     },
     "mime-db": {
@@ -8631,21 +8564,6 @@
             "wrap-ansi": "^5.1.0"
           }
         },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -8793,6 +8711,12 @@
             "ansi-regex": "^4.1.0"
           }
         },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        },
         "supports-color": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
@@ -8800,6 +8724,15 @@
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
           }
         },
         "wrap-ansi": {
@@ -8850,9 +8783,9 @@
       "dev": true
     },
     "n3": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.7.0.tgz",
-      "integrity": "sha512-8R0Qj545WnVLQxOfxxyFKzOpO13hF3jhSMJfO0FNqvbsPZDiR9ZDmGGjXAlcoZDf/88OsCYd7rHML284vm1h6A==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.8.0.tgz",
+      "integrity": "sha512-/PEmoB3UJrG6aXGZenDHFBJtmPp2rtfB2YLzAm2dU9stInD+ztvy4fKv5fv2ggsrSlpu7BYDTsz/c6S391uuEg==",
       "dev": true,
       "requires": {
         "queue-microtask": "^1.1.2",
@@ -8887,12 +8820,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
-      "dev": true
-    },
-    "nested-error-stacks": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.0.1.tgz",
-      "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
       "dev": true
     },
     "nise": {
@@ -8958,18 +8885,6 @@
         "resolve": "^1.17.0",
         "semver": "^7.3.2",
         "validate-npm-package-license": "^3.0.1"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.19.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.1.0",
-            "path-parse": "^1.0.6"
-          }
-        }
       }
     },
     "normalize-path": {
@@ -8997,12 +8912,6 @@
       "requires": {
         "path-key": "^3.0.0"
       }
-    },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
     },
     "object-assign": {
       "version": "2.1.1",
@@ -9113,6 +9022,15 @@
         "wrappy": "1"
       }
     },
+    "one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dev": true,
+      "requires": {
+        "fn.name": "1.x.x"
+      }
+    },
     "onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -9129,9 +9047,9 @@
       "dev": true
     },
     "open": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.3.1.tgz",
-      "integrity": "sha512-f2wt9DCBKKjlFbjzGb8MOAW8LH8F0mrs1zc7KTjAJ9PZNQbfenzWbNP1VZJvw6ICMG9r14Ah6yfwPn7T7i646A==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.0.tgz",
+      "integrity": "sha512-PGoBCX/lclIWlpS/R2PQuIR4NJoXh6X5AwVzE7WXnWRGvHg7+4TBCgsujUgiPpm0K1y4qvQeWnCWVTpTKZBtvA==",
       "dev": true,
       "requires": {
         "is-docker": "^2.0.0",
@@ -9213,9 +9131,9 @@
       }
     },
     "parse-json": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
-      "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -9232,12 +9150,6 @@
       "requires": {
         "xtend": "~4.0.1"
       }
-    },
-    "parse-passwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-      "dev": true
     },
     "parse5": {
       "version": "6.0.1",
@@ -9291,6 +9203,14 @@
       "dev": true,
       "requires": {
         "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
       }
     },
     "path-type": {
@@ -9300,21 +9220,15 @@
       "dev": true
     },
     "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "picomatch": {
@@ -9404,18 +9318,13 @@
         }
       }
     },
-    "pkginfo": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
-      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
-      "dev": true
-    },
     "playwright": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.7.1.tgz",
-      "integrity": "sha512-dOSWME42wDedJ/PXv8k0zG0Kxd6d6R2OKA51/05++Z2ISdA4N58gHlWqlVKPDkBog1MI6lu/KNt7QDn19AybWQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.8.1.tgz",
+      "integrity": "sha512-nmuiDEDwB/SdAxiZQS5pLqPS3XXN8OJ1LKvTSiAbJvu+AUf7f0RD7nuq9xB0C08Emd6stx9yBMhANvD12k/+GQ==",
       "dev": true,
       "requires": {
+        "commander": "^6.1.0",
         "debug": "^4.1.1",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.0",
@@ -9437,6 +9346,12 @@
           "requires": {
             "debug": "4"
           }
+        },
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
         },
         "debug": {
           "version": "4.3.1",
@@ -9491,6 +9406,15 @@
         "mkdirp": "^0.5.5"
       },
       "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
         "debug": {
           "version": "3.2.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -9546,6 +9470,12 @@
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
           "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "node-fetch": {
@@ -9795,12 +9725,12 @@
       "dev": true
     },
     "proper-lockfile": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.1.tgz",
-      "integrity": "sha512-1w6rxXodisVpn7QYvLk706mzprPTAPCYAqxMvctmPN3ekuRk/kuGkGc82pangZiAt4R3lwSuUzheTTn0/Yb7Zg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
+        "graceful-fs": "^4.2.4",
         "retry": "^0.12.0",
         "signal-exit": "^3.0.2"
       }
@@ -9902,9 +9832,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
       "dev": true
     },
     "queue-microtask": {
@@ -9952,18 +9882,6 @@
         }
       }
     },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      }
-    },
     "rdf-data-factory": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.0.4.tgz",
@@ -9971,6 +9889,16 @@
       "dev": true,
       "requires": {
         "@types/rdf-js": "*"
+      }
+    },
+    "rdf-isomorphic": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-1.2.0.tgz",
+      "integrity": "sha512-Dq+iuWrVuK7q3P4/nychbWhRJ1M5yMAekNJN8f5pjarE8SH9Duy/R0JopVF0I0Q2w0poZlsVKKIBpeG+AdOSAw==",
+      "dev": true,
+      "requires": {
+        "rdf-string": "^1.5.0",
+        "rdf-terms": "^1.6.2"
       }
     },
     "rdf-literal": {
@@ -9981,6 +9909,45 @@
       "requires": {
         "@types/rdf-js": "*",
         "rdf-data-factory": "^1.0.1"
+      }
+    },
+    "rdf-object": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-1.8.0.tgz",
+      "integrity": "sha512-/yq5vk8eqspZwIcK1BS3wPcmv4kinooaPX5SRDpCnthCjOcDiyNgPnfXqMt5OpDWhykDkNJeTCvqQifFqZRPyw==",
+      "dev": true,
+      "requires": {
+        "jsonld-context-parser": "^2.0.2",
+        "rdf-data-factory": "^1.0.3",
+        "rdf-string": "^1.5.0",
+        "streamify-array": "^1.0.1"
+      }
+    },
+    "rdf-parse": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-1.7.0.tgz",
+      "integrity": "sha512-P3meLRU9OkZZz9OYq26VeRrxIDrzEBNAScAWcTX1tsf4Z85WTLhiwP5jC+OZBSzRSlybkkb6EYSVA1M4eykiBg==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-http-native": "~1.19.0",
+        "@comunica/actor-rdf-parse-html": "~1.19.0",
+        "@comunica/actor-rdf-parse-html-microdata": "~1.19.0",
+        "@comunica/actor-rdf-parse-html-rdfa": "~1.19.0",
+        "@comunica/actor-rdf-parse-html-script": "~1.19.0",
+        "@comunica/actor-rdf-parse-jsonld": "~1.19.0",
+        "@comunica/actor-rdf-parse-n3": "~1.19.0",
+        "@comunica/actor-rdf-parse-rdfxml": "~1.19.0",
+        "@comunica/actor-rdf-parse-xml-rdfa": "~1.19.0",
+        "@comunica/bus-http": "~1.19.0",
+        "@comunica/bus-init": "~1.19.0",
+        "@comunica/bus-rdf-parse": "~1.19.0",
+        "@comunica/bus-rdf-parse-html": "~1.19.0",
+        "@comunica/core": "~1.19.0",
+        "@comunica/mediator-combine-union": "~1.19.0",
+        "@comunica/mediator-number": "~1.19.0",
+        "@comunica/mediator-race": "~1.19.0",
+        "@types/rdf-js": "*",
+        "stream-to-string": "^1.2.0"
       }
     },
     "rdf-quad": {
@@ -10042,6 +10009,29 @@
         "htmlparser2": "^5.0.0",
         "rdf-data-factory": "^1.0.2",
         "relative-to-absolute-iri": "^1.0.2"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+          "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1"
+          }
+        },
+        "htmlparser2": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz",
+          "integrity": "sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.3.0",
+            "domutils": "^2.4.2",
+            "entities": "^2.0.0"
+          }
+        }
       }
     },
     "rdfxml-streaming-parser": {
@@ -10084,16 +10074,6 @@
             "resolve": "^1.10.0",
             "semver": "2 || 3 || 4 || 5",
             "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "resolve": {
-          "version": "1.19.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.1.0",
-            "path-parse": "^1.0.6"
           }
         },
         "semver": {
@@ -10234,42 +10214,6 @@
         "to-string-x": "^1.4.2"
       }
     },
-    "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
-        }
-      }
-    },
     "require-coercible-to-string-x": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/require-coercible-to-string-x/-/require-coercible-to-string-x-1.0.2.tgz",
@@ -10307,17 +10251,6 @@
         "is-nil-x": "^1.4.2"
       }
     },
-    "requireg": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/requireg/-/requireg-0.1.8.tgz",
-      "integrity": "sha512-qjbwnviLXg4oZiAFEr1ExbevkUPaEiP1uPGSoFCVgCCcbo4PXv9SmiJpXNYmgTBCZ8fY1Jy+sk7F9/kPNepeDw==",
-      "dev": true,
-      "requires": {
-        "nested-error-stacks": "~2.0.1",
-        "rc": "~1.2.7",
-        "resolve": "~1.7.1"
-      }
-    },
     "requireindex": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
@@ -10325,22 +10258,13 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
-      }
-    },
-    "resolve-dir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-      "dev": true,
-      "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-from": {
@@ -10448,16 +10372,22 @@
       }
     },
     "rollup": {
-      "version": "2.36.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.36.1.tgz",
-      "integrity": "sha512-eAfqho8dyzuVvrGqpR0ITgEdq0zG2QJeWYh+HeuTbpcaXk8vNFc48B7bJa1xYosTCKx0CuW+447oQOW8HgBIZQ==",
-      "dev": true
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.39.0.tgz",
+      "integrity": "sha512-+WR3bttcq7zE+BntH09UxaW3bQo3vItuYeLsyk4dL2tuwbeSKJuvwiawyhEnvRdRgrII0Uzk00FpctHO/zB1kw==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.1"
+      }
     },
     "run-parallel": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
-      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "rxjs": {
       "version": "6.6.3",
@@ -10509,10 +10439,13 @@
       "optional": true
     },
     "semver": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-      "dev": true
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -10559,15 +10492,24 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "sinon": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.3.tgz",
-      "integrity": "sha512-m+DyAWvqVHZtjnjX/nuShasykFeiZ+nPuEfD4G3gpvKGkXRhkF/6NSt2qN2FjZhfrcHXFzUzI+NLnk+42fnLEw==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.1",
         "@sinonjs/fake-timers": "^6.0.1",
-        "@sinonjs/samsam": "^5.3.0",
+        "@sinonjs/samsam": "^5.3.1",
         "diff": "^4.0.2",
         "nise": "^4.0.4",
         "supports-color": "^7.1.0"
@@ -10612,6 +10554,21 @@
           "requires": {
             "color-convert": "^2.0.1"
           }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         }
       }
     },
@@ -10631,14 +10588,15 @@
       "dev": true
     },
     "sparqlalgebrajs": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.4.0.tgz",
-      "integrity": "sha512-6glKn1uWBsdPuQ4D+4r5m8mgWZoMfiNgip4uyblULTmgISqcbsQzrlrIhWQoZSX95QLLlWlYJufhelQAIRAWKg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.5.0.tgz",
+      "integrity": "sha512-dNJf4xUj5DFZc/9vQnDU5y9u8l4MfvOkMgx6PAefhTjAK0HHChxLZFF4n6GngWfvEZQ3/HcfmQk3cQo6sT/6bQ==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "minimist": "^1.2.5",
         "rdf-data-factory": "^1.0.0",
+        "rdf-isomorphic": "^1.2.0",
         "rdf-string": "^1.5.0",
         "sparqljs": "^3.1.1"
       },
@@ -10693,9 +10651,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.39",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.39.tgz",
-          "integrity": "sha512-wct+WgRTTkBm2R3vbrFOqyZM5w0g+D8KnhstG9463CJBVC3UVZHMToge7iMBR1vDl/I+NWFHUeK9X+JcF0rWKw==",
+          "version": "13.13.41",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.41.tgz",
+          "integrity": "sha512-qLT9IvHiXJfdrje9VmsLzun7cQ65obsBTmtU3EOnCSLFOoSHx1hpiRHoBnpdbyFqnzqdUUIv81JcEJQCB8un9g==",
           "dev": true
         }
       }
@@ -10723,9 +10681,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.39",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.39.tgz",
-          "integrity": "sha512-wct+WgRTTkBm2R3vbrFOqyZM5w0g+D8KnhstG9463CJBVC3UVZHMToge7iMBR1vDl/I+NWFHUeK9X+JcF0rWKw==",
+          "version": "13.13.41",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.41.tgz",
+          "integrity": "sha512-qLT9IvHiXJfdrje9VmsLzun7cQ65obsBTmtU3EOnCSLFOoSHx1hpiRHoBnpdbyFqnzqdUUIv81JcEJQCB8un9g==",
           "dev": true
         }
       }
@@ -10771,12 +10729,6 @@
         "through2": "^2.0.2"
       },
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -10825,22 +10777,11 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dev": true,
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
     },
     "statuses": {
       "version": "1.5.0",
@@ -10856,6 +10797,12 @@
       "requires": {
         "promise-polyfill": "^1.1.6"
       }
+    },
+    "streamify-array": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/streamify-array/-/streamify-array-1.0.1.tgz",
+      "integrity": "sha512-ZnswaBcC6B1bhPLSQOlC6CdaDUSzU0wr2lvvHpbHNms8V7+DLd8uEAzDAWpsjxbFkijBHhuObFO/qqu52DZUMA==",
+      "dev": true
     },
     "streamify-string": {
       "version": "1.0.1",
@@ -10967,9 +10914,9 @@
       }
     },
     "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
     "supports-color": {
@@ -10994,9 +10941,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.3.tgz",
-          "integrity": "sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.0.tgz",
+          "integrity": "sha512-svS9uILze/cXbH0z2myCK2Brqprx/+JJYK5pHicT/GQiBfzzhUVAIT6MwqJg8y4xV/zoGsUeuPuwtoiKSGE15g==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -11076,6 +11023,12 @@
       "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
       "dev": true
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -11098,6 +11051,12 @@
         "xtend": ">=4.0.0 <4.1.0-0"
       },
       "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -11247,13 +11206,14 @@
       "dev": true
     },
     "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
       }
     },
     "tr46": {
@@ -11309,6 +11269,12 @@
         "trim-right-x": "^3.0.0"
       }
     },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
+      "dev": true
+    },
     "tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -11331,21 +11297,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
       "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
-      "dev": true
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type-check": {
@@ -11380,9 +11331,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
       "dev": true
     },
     "typescript-lit-html-plugin": {
@@ -11723,16 +11674,6 @@
             "strip-indent": "^1.0.1"
           }
         },
-        "resolve": {
-          "version": "1.19.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.1.0",
-            "path-parse": "^1.0.6"
-          }
-        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -11786,17 +11727,6 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
     },
     "vscode-css-languageservice": {
       "version": "3.0.13",
@@ -11897,9 +11827,9 @@
       }
     },
     "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
@@ -11965,6 +11895,65 @@
         }
       }
     },
+    "winston": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
+      "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
+      "dev": true,
+      "requires": {
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.1.0",
+        "is-stream": "^2.0.0",
+        "logform": "^2.2.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.4.0"
+      }
+    },
+    "winston-transport": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.3.7",
+        "triple-beam": "^1.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -12009,6 +11998,21 @@
             "color-convert": "^2.0.1"
           }
         },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
         "strip-ansi": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -12044,21 +12048,15 @@
       }
     },
     "ws": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-      "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+      "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
       "dev": true
     },
     "xml": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
-      "dev": true
-    },
-    "xmldom": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
-      "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw=",
       "dev": true
     },
     "xtend": {
@@ -12158,21 +12156,6 @@
             "strip-ansi": "^5.2.0",
             "wrap-ansi": "^5.1.0"
           }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-method-documentation",
-  "version": "5.1.9",
+  "version": "5.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-method-documentation",
   "description": "A HTTP method documentation build from AMF model",
-  "version": "5.1.9",
+  "version": "5.1.10",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiMethodDocumentation.js
+++ b/src/ApiMethodDocumentation.js
@@ -753,23 +753,6 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
     ${this._getNavigationTemplate()}`;
   }
 
-  _getMessagesTemplate() {
-    if (this._isAsyncAPI(this.amf)) {
-      const { message } = this;
-      return html`<section class="message-documentation">
-        <api-message-documentation
-          .message="${message}"
-        >
-        </api-message-documentation>
-      </section>
-      `;
-    }
-    return html`
-      ${this._getRequestTemplate()}
-      ${this._getReturnsTemplate()}
-    `;
-  }
-
   _getTitleTemplate() {
     if (this._titleHidden) {
       return '';

--- a/src/ApiMethodDocumentation.js
+++ b/src/ApiMethodDocumentation.js
@@ -321,6 +321,10 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
     return this.endpointUri + this._computeMethodParametersUri(this.method);
   }
 
+  get message() {
+    return this._getMessageForMethod(this.methodName);
+  }
+
   constructor() {
     super();
     this.callbacksOpened = false;
@@ -376,6 +380,9 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
     this.hasCustomProperties = this._computeHasCustomProperties(method);
     this.expects = this._computeExpects(method);
     this.returns = this._computeReturns(method);
+    if (this._isAsyncAPI(this.amf)) {
+      this._overwriteExpects();
+    }
     this.security = this._computeSecurity(method) || this._computeSecurity(this.server);
     const extendsTypes = this._computeExtends(method);
     this.extendsTypes = extendsTypes;
@@ -383,6 +390,14 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
     this.methodSummary = this._getValue(method, this.ns.aml.vocabularies.apiContract.guiSummary);
     this.operationId = this._getValue(method, this.ns.aml.vocabularies.apiContract.operationId);
     this.callbacks = this._computeCallbacks(method);
+  }
+
+  _overwriteExpects() {
+    let expects = this.message;
+    if (Array.isArray(expects)) {
+      [expects] = expects;
+    }
+    this.expects = expects;
   }
 
   _processEndpointChange() {
@@ -733,16 +748,26 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
     ${this._getTraitsTemplate()}
     ${hasCustomProperties ? html`<api-annotation-document .shape="${method}"></api-annotation-document>` : ''}
     ${this._getDescriptionTemplate()}
-    <section class="request-documentation">
-      ${this._getCodeSnippetsTemplate()}
-      ${this._getSecurityTemplate()}
-      ${this._getParametersTemplate()}
-      ${this._getHeadersTemplate()}
-      ${this._getBodyTemplate()}
-      ${this._callbacksTemplate()}
-    </section>
+    ${this._getRequestTemplate()}
     ${this._getReturnsTemplate()}
     ${this._getNavigationTemplate()}`;
+  }
+
+  _getMessagesTemplate() {
+    if (this._isAsyncAPI(this.amf)) {
+      const { message } = this;
+      return html`<section class="message-documentation">
+        <api-message-documentation
+          .message="${message}"
+        >
+        </api-message-documentation>
+      </section>
+      `;
+    }
+    return html`
+      ${this._getRequestTemplate()}
+      ${this._getReturnsTemplate()}
+    `;
   }
 
   _getTitleTemplate() {
@@ -955,9 +980,20 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
       .body="${payload}"></api-body-document>`;
   }
 
+  _getRequestTemplate() {
+    return html`<section class="request-documentation">
+      ${this._getCodeSnippetsTemplate()}
+      ${this._getSecurityTemplate()}
+      ${this._getParametersTemplate()}
+      ${this._getHeadersTemplate()}
+      ${this._getBodyTemplate()}
+      ${this._callbacksTemplate()}
+    </section>`
+  }
+
   _getReturnsTemplate() {
     const { returns } = this;
-    if (!returns || !returns.length) {
+    if (!returns || !returns.length || this._isAsyncAPI(this.amf)) {
       return '';
     }
     const {
@@ -1133,6 +1169,27 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
       return { name: paramName, example: paramExample };
     }
     return undefined;
+  }
+
+  /**
+   * Returns message value depending on operation node method
+   * Subscribe -> returns
+   * Publish -> expects
+   * `undefined` otherwise
+   * @param {String} method Operation method
+   */
+  _getMessageForMethod(method) {
+    if (!method) {
+      return undefined;
+    }
+    switch(method.toLowerCase()) {
+      case 'subscribe':
+        return this.returns;
+      case 'publish':
+        return this.expects;
+      default:
+        return undefined;
+    }
   }
 
   /**

--- a/test/api-method-documentation.test.js
+++ b/test/api-method-documentation.test.js
@@ -282,6 +282,7 @@ describe('<api-method-documentation>', () => {
       const callbacksApi = 'oas-callbacks';
       const asyncApi = 'async-api';
       const apic553 = 'APIC-553';
+      const apic582 = 'APIC-582';
 
       describe('Basic AMF computations', () => {
         let amf;
@@ -888,7 +889,27 @@ describe('<api-method-documentation>', () => {
             assert.equal(newLocal.url, 'http://domain.org/cmt-with-qp-example?orx=foo');
           });
         });
-      })
+      });
+
+      describe('APIC-582', () => {
+        let amf;
+        let element;
+
+        before(async () => {
+          amf = await AmfLoader.load(apic582, compact);
+        });
+
+        beforeEach(async () => {
+          const [endpoint, method] = AmfLoader.lookupEndpointOperation(amf, 'user/signedup', 'subscribe');
+          element = await modelFixture(amf, endpoint, method);
+          await nextFrame();
+        });
+
+        it('should render channel message in request documentation section', async () => {
+          await waitUntil(() => !!element.shadowRoot.querySelector('.request-documentation'), 'request documentation section not rendered');
+          await waitUntil(() => !!element.shadowRoot.querySelector('api-body-document'), 'api-body-document not rendered');
+        });
+      });
     });
   });
 });

--- a/test/api-url.test.js
+++ b/test/api-url.test.js
@@ -2,7 +2,7 @@ import { fixture, assert, nextFrame, html, waitUntil } from '@open-wc/testing';
 import { AmfLoader } from './amf-loader.js';
 import '../api-url.js';
 
-describe('<api-url>', function () {
+describe('<api-url>', () => {
   async function basicFixture() {
 	return fixture(`<api-url></api-url>`);
   }
@@ -50,7 +50,7 @@ describe('<api-url>', function () {
 		  element.amf = amf;
 		  server = AmfLoader.getEncodes(amf)[element._getAmfKey(element.ns.aml.vocabularies.apiContract.server)];
 		  if (Array.isArray(server)) {
-			server = server[0];
+			[server] = server;
 		  }
 		  element = await operationFixture({ amf, endpoint, operation, server });
 		  // model change debouncer
@@ -100,7 +100,7 @@ describe('<api-url>', function () {
 		  element.amf = amf;
 		  server = AmfLoader.getEncodes(amf)[element._getAmfKey(element.ns.aml.vocabularies.apiContract.server)];
 		  if (Array.isArray(server)) {
-			server = server[0];
+			[server] = server;
 		  }
 		  element = await operationFixture({ amf, endpoint, operation, server });
 		  // model change debouncer
@@ -131,12 +131,12 @@ describe('<api-url>', function () {
 
 			beforeEach(async () => {
 				const endpointName = 'smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured'
-				const [endpoint, operation] = AmfLoader.lookupEndpointOperation(amf, endpointName, 'kafka');
+				const [endpoint, operation] = AmfLoader.lookupEndpointOperation(amf, endpointName, 'subscribe');
 				element = await basicFixture();
 				element.amf = amf;
 				server = AmfLoader.getEncodes(amf)[element._getAmfKey(element.ns.aml.vocabularies.apiContract.server)];
 				if (Array.isArray(server)) {
-					server = server[0];
+					[server] = server;
 				}
 				element = await operationFixture({ amf, endpoint, operation, server });
 				// model change debouncer
@@ -150,9 +150,9 @@ describe('<api-url>', function () {
 			});
 
 			it('should render server', async () => {
-				const server = 'Servermqtt://api.streetlights.smartylighting.com:{port}'
+				const expectedServer = 'Servermqtt://api.streetlights.smartylighting.com:{port}'
 				await waitUntil(() => element.shadowRoot.querySelector('.url-server-value'));
-				assert.equal(element.shadowRoot.querySelector('.url-server-value').textContent, server);
+				assert.equal(element.shadowRoot.querySelector('.url-server-value').textContent, expectedServer);
 			});
 
 			it('should only render url value when no operation selected', async () => {


### PR DESCRIPTION
AMF model assigns the message schema object to either the `expects` node or the `returns` node, depending on whether the operation is `publish` or `subscribe` respectively.

For AsyncAPIs, do not render the response section, only render the request section. To ensure compatibility, if the API is an AsyncAPI, then overwrite the `expects` value of the component to match either the `expects` or `returns` node of the operation, depending on the operation's method.