### PR TITLE
Fix/APIC-626/lost change event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-method-documentation",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-method-documentation",
   "description": "A HTTP method documentation build from AMF model",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiUrl.js
+++ b/src/ApiUrl.js
@@ -249,7 +249,8 @@ export class ApiUrl extends AmfHelperMixin(LitElement) {
     return name;
   }
 
-  _dispatchChangeEvent() {
+  async _dispatchChangeEvent() {
+    await this.updateComplete
     this.dispatchEvent(
       new CustomEvent('change', {
         bubbles: true,


### PR DESCRIPTION
APIC-626: apiUrl change event lost.
Fix: Fire change event after apiUrl has completed updating.