### PR TITLE
Fix border bottom style

### DIFF
--- a/src/Styles.js
+++ b/src/Styles.js
@@ -102,8 +102,9 @@ export default css`
   display: flex;
   flex-direction: row;
   align-items: center;
-  border-bottom: 1px var(--api-parameters-document-title-border-color, #e5e5e5) solid;
-  border: var(--api-parameters-document-title-border);
+  border-bottom: var(--api-parameters-document-title-border-bottom,
+    1px var(--api-parameters-document-title-border-color, #e5e5e5) solid
+  );
   cursor: pointer;
   user-select: none;
   transition: border-bottom-color 0.15s ease-in-out;

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -85,9 +85,7 @@ export default css`
   font-size: var(--api-method-documentation-url-font-size, 1.07rem);
   font-weight: var(--api-method-documentation-url-font-weight);
   line-height: var(--api-method-documentation-url-line-height);
-  margin-bottom: 40px;
-  margin-top: 20px;
-  margin: var(--api-method-documentation-url-margin);
+  margin: var(--api-method-documentation-url-margin, 20px 0 40px 0);
   background-color: var(--api-method-documentation-url-background-color, var(--code-background-color));
   color: var(
     --api-method-documentation-url-font-color,


### PR DESCRIPTION
- Fixes `border` property overriding the style of `border-bottom` when the CSS variable is undefined
( https://github.com/advanced-rest-client/api-method-documentation/pull/38#discussion_r637599230 )

- Fixes `margin` property overriding default `margin-top` and `margin-bottom` style on `.url-area`
( https://github.com/advanced-rest-client/api-method-documentation/commit/3d6a35a3804f9824a7610be8b73d6e1a34378d62#r51355569 )