### PR TITLE
Fix/wrong uri parameter

### DIFF
--- a/demo/APIC-650/APIC-650.yaml
+++ b/demo/APIC-650/APIC-650.yaml
@@ -1,0 +1,20 @@
+openapi: "3.0.0"
+info:
+  version: v1
+  title: test-api-spec-for-support-case
+paths: 
+  /testEndpoint1/{uriParam1}:
+    get:
+      parameters:
+        - $ref: "common-parameters.yaml#/components/parameters/UriParam1"
+      description: Test endpoint 1.
+      responses:
+        '200':
+
+  /testEndpoint2/{uriParam2}:
+    get:
+      parameters:
+        - $ref: "common-parameters.yaml#/components/parameters/UriParam2"
+      description: Test endpoint 2.
+      responses:
+        '200':

--- a/demo/APIC-650/common-parameters.yaml
+++ b/demo/APIC-650/common-parameters.yaml
@@ -1,0 +1,39 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: common-parameters
+paths: {}
+components:
+  parameters:
+    UriParam1:
+      name: uriParam1
+      in: path
+      description: uri param for testEndpoint 1 
+      required: true
+      schema:
+        type: string
+        example: "uriParam1Example"
+    UriParam2:
+      name: uriParam2
+      in: path
+      description: uri param for testEndpoint 2 
+      required: true
+      schema:
+        type: string
+        example: "uriParam2Example"
+    QueryParam1:
+      name: queryParam1
+      in: query
+      description: query param for testEndpoint 1 
+      required: true
+      schema:
+        type: string
+        example: "queryParam1Example"
+    QueryParam2:
+      name: queryParam2
+      in: query
+      description: query param for testEndpoint 2
+      required: true
+      schema:
+        type: string
+        example: "queryParam2Example"

--- a/demo/APIC-650/common-parameters.yaml
+++ b/demo/APIC-650/common-parameters.yaml
@@ -21,19 +21,3 @@ components:
       schema:
         type: string
         example: "uriParam2Example"
-    QueryParam1:
-      name: queryParam1
-      in: query
-      description: query param for testEndpoint 1 
-      required: true
-      schema:
-        type: string
-        example: "queryParam1Example"
-    QueryParam2:
-      name: queryParam2
-      in: query
-      description: query param for testEndpoint 2
-      required: true
-      schema:
-        type: string
-        example: "queryParam2Example"

--- a/demo/apis.json
+++ b/demo/apis.json
@@ -13,5 +13,6 @@
   "async-api/async-api.yaml": "ASYNC 2.0",
   "APIC-553/APIC-553.raml": "RAML 1.0",
   "APIC-560/APIC-560.yaml": "ASYNC 2.0",
-  "APIC-582/APIC-582.yaml": "ASYNC 2.0"
+  "APIC-582/APIC-582.yaml": "ASYNC 2.0",
+  "APIC-650/APIC-650.yaml": "OAS 3.0"
 }

--- a/demo/index.js
+++ b/demo/index.js
@@ -109,6 +109,7 @@ class ComponentDemo extends ApiDemoPage {
       const item = methods[i];
       if (item['@id'] !== id) {
         last = item;
+        // eslint-disable-next-line no-continue
         continue;
       }
       this.method = item;
@@ -163,6 +164,7 @@ class ComponentDemo extends ApiDemoPage {
       ['oas-callbacks', 'OAS 3 callbacks'],
       ['async-api', 'Async API'],
       ['APIC-560', 'APIC-560'],
+      ['APIC-650', 'APIC-650'],
     ].map(([file, label]) => html`
       <anypoint-item data-src="${file}-compact.json">${label} - compact model</anypoint-item>
       <anypoint-item data-src="${file}.json">${label}</anypoint-item>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-method-documentation",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-method-documentation",
   "description": "A HTTP method documentation build from AMF model",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiMethodDocumentation.js
+++ b/src/ApiMethodDocumentation.js
@@ -413,9 +413,7 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
   }
 
   _expectsChanged(expects) {
-    if (!this.endpointVariables) {
-      this._processEndpointVariables();
-    }
+    this._processEndpointVariables();
     this.headers = this._computeHeaders(expects);
     this.payload = this._computePayload(expects);
     this.queryParameters = this._computeQueryParameters(expects);

--- a/test/amf-loader.js
+++ b/test/amf-loader.js
@@ -8,7 +8,7 @@ window.customElements.define('helper-element', HelperElement);
 
 const helper = new HelperElement();
 
-AmfLoader.load = async function(fileName, compact) {
+AmfLoader.load = async (fileName, compact) => {
   const compactValue = compact ? '-compact' : '';
   const file = `${fileName}${compactValue}.json`;
   const url = `${window.location.protocol}//${window.location.host}/base/demo/${file}`;
@@ -19,9 +19,9 @@ AmfLoader.load = async function(fileName, compact) {
       try {
         data = JSON.parse(e.target.response);
         /* istanbul ignore next */
-      } catch (e) {
+      } catch (error) {
         /* istanbul ignore next */
-        reject(e);
+        reject(error);
         /* istanbul ignore next */
         return;
       }
@@ -35,26 +35,26 @@ AmfLoader.load = async function(fileName, compact) {
   });
 };
 
-AmfLoader.lookupEndpoint = function(model, endpoint) {
+AmfLoader.lookupEndpoint = (model, endpoint) => {
   helper.amf = model;
   const webApi = helper._computeApi(model);
   return helper._computeEndpointByPath(webApi, endpoint);
 };
 
-AmfLoader.lookupOperation = function(model, endpoint, operation) {
+AmfLoader.lookupOperation = (model, endpoint, operation) => {
   const endPoint = AmfLoader.lookupEndpoint(model, endpoint);
   const opKey = helper._getAmfKey(helper.ns.aml.vocabularies.apiContract.supportedOperation);
   const ops = helper._ensureArray(endPoint[opKey]);
   return ops.find((item) => helper._getValue(item, helper.ns.aml.vocabularies.apiContract.method) === operation);
 };
 
-AmfLoader.lookupPayload = function(model, endpoint, operation) {
+AmfLoader.lookupPayload = (model, endpoint, operation) => {
   const op = AmfLoader.lookupOperation(model, endpoint, operation);
   const expects = helper._computeExpects(op);
   return helper._ensureArray(helper._computePayload(expects));
 };
 
-AmfLoader.lookupEndpointOperation = function(model, endpoint, operation) {
+AmfLoader.lookupEndpointOperation = (model, endpoint, operation) => {
   const endPoint = AmfLoader.lookupEndpoint(model, endpoint);
   const opKey = helper._getAmfKey(helper.ns.aml.vocabularies.apiContract.supportedOperation);
   const ops = helper._ensureArray(endPoint[opKey]);
@@ -62,11 +62,14 @@ AmfLoader.lookupEndpointOperation = function(model, endpoint, operation) {
   return [endPoint, op];
 };
 
-AmfLoader.getEncodes = function(model) {
-  return helper._computeEncodes(model)
-}
+AmfLoader.getEncodes = model => helper._computeEncodes(model)
 
-AmfLoader.getServers = function(model) {
+AmfLoader.getServers = model => {
   helper.amf = model;
   return helper._getServers({});
+}
+
+AmfLoader.getParamName = model => {
+  helper.amf = model;
+  return helper._getValue(model, helper.ns.aml.vocabularies.apiContract.paramName);
 }

--- a/test/api-method-documentation.test.js
+++ b/test/api-method-documentation.test.js
@@ -912,4 +912,35 @@ describe('<api-method-documentation>', () => {
       });
     });
   });
+
+  describe('APIC-650', () => {
+    let amf;
+    let element;
+
+    before(async () => {
+      amf = await AmfLoader.load('APIC-650');
+    });
+
+    beforeEach(async () => {
+      const [endpoint, method] = AmfLoader.lookupEndpointOperation(amf, '/testEndpoint1/{uriParam1}', 'get');
+      element = await modelFixture(amf, endpoint, method);
+      // model change debouncer
+      await aTimeout();
+    });
+
+    it('endpointVariables is computed', () => {
+      assert.typeOf(element.endpointVariables, 'array');
+      assert.equal(AmfLoader.getParamName(element.endpointVariables[0]), 'uriParam1')
+    });
+
+    it('endpointVariables updated after selection changes', async () => {
+      const [endpoint, method] = AmfLoader.lookupEndpointOperation(amf, '/testEndpoint2/{uriParam2}', 'get');
+      element.endpoint = endpoint;
+      element.method = method;
+      await aTimeout();
+
+      assert.typeOf(element.endpointVariables, 'array');
+      assert.equal(AmfLoader.getParamName(element.endpointVariables[0]), 'uriParam2')
+    });
+  });
 });


### PR DESCRIPTION
When going back and forth between endpoints URI Parameters are not populated correctly, they belong to the other endpoint.