### PR TITLE
[W-11105366] missing expect

### DIFF
--- a/demo/apis.json
+++ b/demo/apis.json
@@ -14,6 +14,7 @@
   "APIC-553/APIC-553.raml": "RAML 1.0",
   "APIC-560/APIC-560.yaml": "ASYNC 2.0",
   "APIC-582/APIC-582.yaml": "ASYNC 2.0",
+  "multiple-messages/multiple-messages.yaml": "ASYNC 2.0",
   "APIC-650/APIC-650.yaml": "OAS 3.0",
   "APIC-758/APIC-758.yaml": "OAS 3.0"
 }

--- a/demo/index.js
+++ b/demo/index.js
@@ -165,6 +165,7 @@ class ComponentDemo extends ApiDemoPage {
       ['async-api', 'Async API'],
       ['APIC-560', 'APIC-560'],
       ['APIC-650', 'APIC-650'],
+      ['multiple-messages', 'multiple-messages'],
     ].map(([file, label]) => html`
       <anypoint-item data-src="${file}-compact.json">${label} - compact model</anypoint-item>
       <anypoint-item data-src="${file}.json">${label}</anypoint-item>

--- a/demo/multiple-messages/multiple-messages.yaml
+++ b/demo/multiple-messages/multiple-messages.yaml
@@ -1,0 +1,68 @@
+asyncapi: '2.0.0'
+info:
+  title: exp-shipping-sftp-async
+  description: This api processes Shipping Notification messages and converts them to a CDM.
+  version: '1.0.0'
+
+servers:
+  Dev:
+    protocol: anypointmq
+    protocolVersion: v1
+    url: https://mq-eu-west-2.anypoint.mulesoft.com/api/v1
+    description: Development Instance
+    security:
+        - clientIdEnforcement: []
+
+channels:
+  shipping-messages:
+    description: Converted Shipping Notification messages are published on this channel.
+    subscribe:
+      description: Converted Shipping Notification messages can be subscribed to via this channel.
+      message:
+          oneOf:
+            - $ref: '#/components/messages/ASN'
+            - $ref: '#/components/messages/GRN'
+
+components:
+  securitySchemes:
+    clientIdEnforcement:
+      description: Client ID Enforcement
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://mq-eu-west-2.anypoint.mulesoft.com/api/v1/authorize
+          scopes: {}
+
+  messages:
+    ASN:
+      contentType: application/json
+      headers:
+        type: object
+        description: Message header
+        properties:
+          messageId:
+            description: Message ID field
+            type: string
+      payload:
+        type: object
+        description: Message payload
+        properties:
+          data1:
+            description: Data 1 field
+            type: string
+    GRN:
+      contentType: application/json
+      headers:
+        type: object
+        description: Message header
+        properties:
+          messageId:
+            description: Message ID field
+            type: string
+      payload:
+        type: object
+        description: Message payload
+        properties:
+          data2:
+            description: Data 2 field
+            type: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -841,9 +841,9 @@
       }
     },
     "@api-components/amf-helper-mixin": {
-      "version": "4.5.17",
-      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.5.17.tgz",
-      "integrity": "sha512-CGMo/N/wb8jwg7n98tpfj5VqBVyB4jDyyGQ/fdgLacQrEQ5Fe0v0hG8Maj2OOQeavt44y3SMbSLCQBjsxchbAA==",
+      "version": "4.5.19",
+      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.5.19.tgz",
+      "integrity": "sha512-LNn4+iDAH6QK2WYz2IdnUI4kp6iZsp9Fni62V5fBpYsACnXrZA7PmyB00YCaLWn3PKlaw08W2XVGdphiTspORA==",
       "requires": {
         "amf-json-ld-lib": "0.0.14"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-method-documentation",
-  "version": "5.2.8",
+  "version": "5.2.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@advanced-rest-client/markdown-styles": "^3.1.4",
     "@anypoint-web-components/anypoint-button": "^1.2.3",
     "@anypoint-web-components/anypoint-collapse": "^0.1.0",
-    "@api-components/amf-helper-mixin": "^4.5.14",
+    "@api-components/amf-helper-mixin": "^4.5.19",
     "@api-components/api-annotation-document": "^4.2.1",
     "@api-components/api-body-document": "^4.4.4",
     "@api-components/api-example-generator": "^4.4.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-method-documentation",
   "description": "A HTTP method documentation build from AMF model",
-  "version": "5.2.8",
+  "version": "5.2.9",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiMethodDocumentation.js
+++ b/src/ApiMethodDocumentation.js
@@ -393,11 +393,7 @@ export class ApiMethodDocumentation extends AmfHelperMixin(LitElement) {
   }
 
   _overwriteExpects() {
-    let expects = this.message;
-    if (Array.isArray(expects)) {
-      [expects] = expects;
-    }
-    this.expects = expects;
+    this.expects = this.message;
   }
 
   _processEndpointChange() {

--- a/test/api-method-documentation.test.js
+++ b/test/api-method-documentation.test.js
@@ -284,6 +284,7 @@ describe('<api-method-documentation>', () => {
       const apic553 = 'APIC-553';
       const apic582 = 'APIC-582';
       const apic758 = 'APIC-758';
+      const multipleMessages = 'multiple-messages';
 
       describe('Basic AMF computations', () => {
         let amf;
@@ -824,6 +825,30 @@ describe('<api-method-documentation>', () => {
             'api-headers-document renders',
             { timeout: 1000 },
           );
+        });
+
+        describe('Multiple messages', () => {
+          let amf;
+          let element;
+
+          before(async () => {
+            amf = await AmfLoader.load(multipleMessages, compact);
+          });
+
+          beforeEach(async () => {
+            const [endpoint, method] = AmfLoader.lookupEndpointOperation(amf, 'shipping-messages', 'subscribe');
+            element = await modelFixture(amf, endpoint, method);
+            // model change debouncer
+            await aTimeout();
+          });
+
+          it('expects is computed', () => {
+            assert.typeOf(element.expects, 'array');
+          });
+
+          it('expects has two elements', () => {
+            assert.equal(element.expects.length, 2);
+          });
         });
       });
 


### PR DESCRIPTION
Bug: doesn't render both messages in documentation for subscribe message

For the following spec:

channels:
shipping-messages:
description: Converted Shipping Notification messages are published on this channel.
subscribe:
description: Converted Shipping Notification messages can be subscribed to via this channel.
message:
oneOf:
- $ref: '#/components/messages/ASN'
- $ref: '#/components/messages/GRN'

This PR includes:
- Bug fix
- Bump amf-helper-mixin to latest version